### PR TITLE
feat(datum-platform): add commit message conventions skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes to the Datum Cloud Claude Code plugins.
 
+## [1.4.0] - 2026-02-20
+
+### Added
+
+- **Commit conventions skill** (`commit-conventions`) — Standardized commit message guidelines based on the seven rules from cbea.ms/git-commit. Provides format, structure, and content guidance for consistent commit history across repositories. Agents prompt for clarification when commit purpose is unclear.
+
 ## [1.3.0] - 2026-02-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A marketplace for Claude Code plugins providing platform engineering tools and a
 
 | Plugin | Description | Version |
 |--------|-------------|---------|
-| [datum-platform](./plugins/datum-platform/) | Kubernetes platform engineering automation with aggregated API servers, controller patterns, and GitOps deployment | 1.3.0 |
+| [datum-platform](./plugins/datum-platform/) | Kubernetes platform engineering automation with aggregated API servers, controller patterns, and GitOps deployment | 1.4.0 |
 | [datum-gtm](./plugins/datum-gtm/) | Go-to-market automation with commercial strategy, product discovery, and customer support | 1.0.0 |
 
 ## Installation
@@ -117,7 +117,7 @@ Kubernetes platform engineering automation with aggregated API servers, controll
 
 **Features:**
 - 6 specialized agents (api-dev, frontend-dev, sre, test-engineer, code-reviewer, tech-writer)
-- 24 skill modules covering Kubernetes patterns, Go conventions, deployment workflows, and more
+- 25 skill modules covering Kubernetes patterns, Go conventions, deployment workflows, and more
 - Pipeline orchestration for structured feature development
 - Automatic learning engine for pattern extraction
 

--- a/plugins/datum-platform/.claude-plugin/plugin.json
+++ b/plugins/datum-platform/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datum-platform",
   "description": "Kubernetes platform engineering automation with aggregated API servers, controller patterns, GitOps deployment, and platform capabilities",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Datum Cloud",
     "url": "https://github.com/datum-cloud"

--- a/plugins/datum-platform/skills/commit-conventions/SKILL.md
+++ b/plugins/datum-platform/skills/commit-conventions/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: commit-conventions
+description: Covers commit message conventions including format, structure, and content guidelines. Use when writing commits to ensure consistent, meaningful commit history across Datum Cloud repositories.
+---
+
+# Commit Conventions
+
+This skill covers commit message conventions for all Datum Cloud repositories.
+
+## Overview
+
+Write commit messages for future maintainers who need context months or years later. A well-crafted commit history enables effective use of `git log`, `blame`, `revert`, and `rebase`.
+
+## The Seven Rules
+
+Based on [How to Write a Git Commit Message](https://cbea.ms/git-commit/):
+
+| Rule | Guidance |
+|------|----------|
+| 1. Separate subject from body with blank line | Required for multi-line commits |
+| 2. Limit subject line to 50 characters | 50 is target, 72 is hard limit |
+| 3. Capitalize the subject line | Begin with capital letter after type prefix |
+| 4. Do not end subject with a period | Conserves space, cleaner appearance |
+| 5. Use imperative mood | "Add feature" not "Added feature" |
+| 6. Wrap body at 72 characters | Allows Git indentation in diffs |
+| 7. Use body to explain what and why | Code shows how; commit explains why |
+
+## Format
+
+Use Conventional Commits format:
+
+```
+<type>: <subject>
+
+<body>
+
+<trailers>
+```
+
+### Types
+
+| Type | Use When |
+|------|----------|
+| `feat` | Adding new functionality |
+| `fix` | Fixing a bug |
+| `docs` | Documentation only changes |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `test` | Adding or updating tests |
+| `chore` | Maintenance tasks, dependencies, tooling |
+
+### Subject Line
+
+- Start with type prefix: `feat:`, `fix:`, etc.
+- Capitalize first letter after the colon
+- Use imperative mood: "Add" not "Added" or "Adds"
+- No period at the end
+- Keep under 50 characters (72 hard limit)
+
+**Imperative mood test**: "If applied, this commit will [subject]"
+
+```
+feat: Add user authentication endpoint     ✓ reads naturally
+feat: Added user authentication endpoint   ✗ awkward phrasing
+feat: Adding user authentication endpoint  ✗ awkward phrasing
+```
+
+## When to Include a Body
+
+**Single-line commits** are acceptable for:
+- Typo fixes
+- Obvious bug fixes
+- Simple, self-explanatory changes
+
+**Include a body** for:
+- Non-trivial changes
+- Changes requiring context
+- Anything where "why" isn't obvious from the diff
+
+## Body Content
+
+Focus on **why**, not **what** (the diff shows what changed).
+
+Answer these questions:
+- What problem does this solve?
+- Why was this approach chosen over alternatives?
+- What context will future maintainers need?
+
+### Formatting
+
+- Wrap at 72 characters
+- Use blank lines between paragraphs
+- Use bullet points with hyphens for lists
+- Place issue references at the end
+
+## Examples
+
+### Good: Simple Change
+
+```
+fix: Correct typo in error message
+```
+
+### Good: With Context
+
+```
+feat: Add rate limiting to API endpoints
+
+The public API was vulnerable to abuse from automated clients
+making excessive requests. This adds a token bucket rate limiter
+with configurable limits per endpoint.
+
+Default limits are set conservatively (100 req/min) and can be
+adjusted via environment variables.
+
+Resolves: #234
+```
+
+### Good: Explaining Why
+
+```
+refactor: Extract validation logic into separate package
+
+Validation rules were duplicated across three controllers. Moving
+them to a shared package reduces maintenance burden and ensures
+consistent behavior.
+
+This is a pure refactor with no behavior changes.
+```
+
+### Bad: No Context
+
+```
+fix: Fix the bug
+```
+
+Why is this bad? Which bug? What was wrong? Future maintainers have no context.
+
+### Bad: Describes What, Not Why
+
+```
+refactor: Move function to different file
+```
+
+Why is this bad? The diff already shows this. Why was it moved?
+
+### Bad: Too Long
+
+```
+feat: add new user authentication endpoint that validates credentials and returns JWT tokens
+```
+
+Why is this bad? Exceeds 72 characters. Use body for details.
+
+## Agent Behavior
+
+When generating commit messages:
+
+1. **Clarify purpose** — If uncertain why changes are being made, ask the user before committing
+2. **Confirm details** — When context is unclear, prompt for clarification
+3. **Write for humans** — Messages should be descriptive and readable
+4. **Include rationale** — Explain why changes were made, not just what changed
+
+## Co-Authored-By Trailer
+
+Claude Code agents include the Co-Authored-By trailer:
+
+```
+feat: Add resource quota enforcement
+
+Implements quota checking at resource creation time to prevent
+tenants from exceeding their allocated limits.
+
+Co-Authored-By: Claude <claude@anthropic.com>
+```
+
+## Commit Structure Template
+
+```
+<type>: <Subject line under 50 chars>
+
+<Explain the problem this solves. Wrap at 72 characters. Focus on
+the motivation and context, not the implementation details.>
+
+<If relevant, explain why this approach was chosen over alternatives.>
+
+<Bullet points are acceptable:>
+- Point one
+- Point two
+
+Resolves: #<issue-number>
+
+Co-Authored-By: Claude <claude@anthropic.com>
+```


### PR DESCRIPTION
## Summary

- Adds `commit-conventions` skill to datum-platform plugin
- Provides standardized commit message guidelines based on [cbea.ms/git-commit](https://cbea.ms/git-commit/)
- Eliminates need for duplicating conventions in each repo's CLAUDE.md

## Changes

- **New skill**: `plugins/datum-platform/skills/commit-conventions/SKILL.md`
- **Version bump**: 1.3.0 → 1.4.0
- **Skill count**: 24 → 25

## Skill Contents

- The seven rules of commit messages (subject/body separation, length limits, imperative mood, etc.)
- Conventional Commits format with type prefixes
- Body content guidance (explain why, not what)
- Good/bad examples with explanations
- Agent behavior requirements (clarify purpose, prompt when unclear)
- Co-Authored-By trailer guidance

## Test plan

- [ ] Validate plugin structure: `claude plugin validate .`
- [ ] Verify skill is discoverable by agents
- [ ] Test commit generation follows new conventions

Closes #2