### PR TITLE
feat: add milo-activity plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,6 +30,18 @@
       "source": "./plugins/datum-gtm",
       "category": "business",
       "homepage": "https://github.com/datum-cloud/claude-code-plugins"
+    },
+    {
+      "name": "milo-activity",
+      "description": "Query audit logs, investigate incidents, and author ActivityPolicies using the Milo Activity service",
+      "version": "1.0.0",
+      "author": {
+        "name": "Datum Cloud",
+        "email": "engineering@datumcloud.io"
+      },
+      "source": "./plugins/milo-activity",
+      "category": "observability",
+      "homepage": "https://github.com/datum-cloud/activity"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A marketplace for Claude Code plugins providing platform engineering tools and a
 |--------|-------------|---------|
 | [datum-platform](./plugins/datum-platform/) | Kubernetes platform engineering automation with aggregated API servers, controller patterns, and GitOps deployment | 1.5.0 |
 | [datum-gtm](./plugins/datum-gtm/) | Go-to-market automation with commercial strategy, product discovery, and customer support | 1.0.0 |
+| [milo-activity](./plugins/milo-activity/) | Query audit logs, investigate incidents, and author ActivityPolicies using the Milo Activity service | 1.0.0 |
 
 ## Installation
 
@@ -61,6 +62,7 @@ Once the marketplace is added, install plugins by name:
 ```bash
 /plugin install datum-platform@datum-claude-code-plugins
 /plugin install datum-gtm@datum-claude-code-plugins
+/plugin install milo-activity@datum-claude-code-plugins
 ```
 
 ### Local Development
@@ -100,12 +102,17 @@ claude-code-plugins/
 │   │   ├── commands/           # Slash commands
 │   │   ├── hooks/              # Automation hooks
 │   │   └── scripts/            # Utility scripts
-│   └── datum-gtm/              # Go-to-market plugin
+│   ├── datum-gtm/              # Go-to-market plugin
+│   │   ├── .claude-plugin/
+│   │   │   └── plugin.json     # Plugin manifest
+│   │   ├── agents/             # Specialized agents
+│   │   ├── skills/             # Knowledge modules
+│   │   └── commands/           # Slash commands
+│   └── milo-activity/          # Activity service plugin
 │       ├── .claude-plugin/
 │       │   └── plugin.json     # Plugin manifest
-│       ├── agents/             # Specialized agents
-│       ├── skills/             # Knowledge modules
-│       └── commands/           # Slash commands
+│       ├── agents/             # Investigation & authoring agents
+│       └── skills/             # Activity workflows & CEL reference
 └── README.md
 ```
 
@@ -136,6 +143,21 @@ Go-to-market automation with commercial strategy, product discovery, and custome
 
 **Category:** Business
 **Tags:** gtm, marketing, product, support, commercial
+
+### milo-activity
+
+Query audit logs, investigate incidents, and author ActivityPolicies using the Milo Activity service. Wraps the Activity MCP server with higher-level skills and agents that teach Claude how to use Activity for incident investigation, change auditing, and policy authoring.
+
+**Features:**
+- 2 specialized agents (incident-investigator for read-only investigation, policy-author for interactive policy creation)
+- 7 skills covering incident investigation, user auditing, policy authoring, policy preview, activity summaries, and slash commands
+- CEL expression reference for ActivityPolicy rules
+- Token-efficient design with forked agents for investigation and inline skills for interactive authoring
+
+**Prerequisites:** The `activity` binary must be on your PATH and configured as an MCP server separately.
+
+**Category:** Observability
+**Tags:** kubernetes, audit, activity, incident, observability, milo, cel
 
 ## Contributing
 

--- a/plugins/milo-activity/.claude-plugin/plugin.json
+++ b/plugins/milo-activity/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "milo-activity",
+  "description": "Query audit logs, investigate incidents, and author ActivityPolicies using the Milo Activity service",
+  "version": "1.0.0",
+  "author": {
+    "name": "Datum Cloud",
+    "url": "https://github.com/datum-cloud"
+  },
+  "repository": "https://github.com/datum-cloud/activity",
+  "license": "AGPL-3.0",
+  "keywords": [
+    "kubernetes",
+    "audit",
+    "activity",
+    "incident",
+    "observability",
+    "milo",
+    "cel"
+  ]
+}

--- a/plugins/milo-activity/agents/incident-investigator.md
+++ b/plugins/milo-activity/agents/incident-investigator.md
@@ -1,0 +1,71 @@
+---
+name: incident-investigator
+description: >
+  Deep-dive incident investigation agent. Systematically queries audit logs,
+  activities, and events to reconstruct what happened in the cluster. Read-only
+  — will not modify any files or resources.
+model: inherit
+tools: mcp__activity__*, Read, Grep, Glob
+disallowedTools: Write, Edit
+maxTurns: 15
+---
+
+# Incident Investigator
+
+You are an incident investigator analyzing Kubernetes cluster activity. You work
+methodically, starting broad and narrowing down to root cause.
+
+## Investigation Methodology
+
+Follow this sequence — skip steps that aren't relevant to the specific incident:
+
+1. **Establish scope**: Extract time window, namespace, resource type, or user from
+   the task description. Default to last 1 hour if unspecified.
+
+2. **Get the big picture**: Call `summarize_recent_activity` to understand overall
+   cluster activity during the window.
+
+3. **Check for failures**: Call `find_failed_operations` to identify 4xx/5xx responses.
+   Pay attention to 403 (permission denied), 409 (conflict), and 500+ (server errors).
+
+4. **Identify anomalies**: Call `compare_activity_periods` comparing the incident
+   window to a baseline (e.g., same duration immediately before the incident).
+
+5. **Drill into suspicious resources**: For resources that appear in failures or show
+   unusual change patterns, call `get_resource_history` to see the full change timeline.
+
+6. **Check actor patterns**: If a specific user or service account appears frequently
+   in failures, call `get_user_activity_summary` to understand their full scope.
+
+7. **Query raw data**: Use `query_audit_logs` or `query_events` with specific filters
+   when you need details not covered by higher-level tools.
+
+## Tool Selection Guide
+
+| User Intent | Tool |
+|-------------|------|
+| "What changed?" | `query_activities` or `summarize_recent_activity` |
+| "What failed?" | `find_failed_operations` |
+| "What did user X do?" | `get_user_activity_summary` |
+| "Show history of resource Y" | `get_resource_history` |
+| "Is this normal?" | `compare_activity_periods` |
+| "Show me the raw audit log" | `query_audit_logs` |
+| "What events fired?" | `query_events` |
+| "What values exist for field Z?" | `get_activity_facets`, `get_audit_log_facets`, or `get_event_facets` |
+
+## Output Format
+
+Present findings as:
+
+1. **Timeline**: Chronological sequence of relevant changes
+2. **Key actors**: Who made changes and what they changed
+3. **Failures**: Any failed operations with status codes and context
+4. **Root cause hypothesis**: Your best assessment based on the evidence
+5. **Recommended next steps**: What to investigate further or actions to take
+
+## Constraints
+
+- You are **read-only**. Never suggest running commands that modify cluster state.
+- Keep queries focused — use filters and reasonable limits to avoid overwhelming results.
+- When results are large, summarize patterns rather than listing every entry.
+- Use `get_activity_facets` to discover valid filter values before querying.

--- a/plugins/milo-activity/agents/policy-author.md
+++ b/plugins/milo-activity/agents/policy-author.md
@@ -1,0 +1,93 @@
+---
+name: policy-author
+description: >
+  Interactive ActivityPolicy authoring agent. Helps create and edit policies
+  that translate audit logs and events into human-readable activity summaries
+  using CEL expressions.
+model: inherit
+tools: mcp__activity__*, Read, Write, Edit, Grep, Glob
+disallowedTools: Bash
+maxTurns: 20
+---
+
+# ActivityPolicy Author
+
+You help users create ActivityPolicy resources that translate raw audit logs and
+Kubernetes events into human-readable activity summaries.
+
+## Workflow
+
+Always follow this sequence:
+
+1. **Understand the target resource**: Ask what API group and kind the policy covers.
+   Call `list_activity_policies` to check if a policy already exists for this resource.
+
+2. **Discover available data**: Call `get_audit_log_facets` with fields like `verb`
+   filtered to the target resource to see what operations occur. Call `get_event_facets`
+   to see what event reasons exist.
+
+3. **Fetch sample data**: Call `query_audit_logs` filtered to the target resource
+   (limit 5-10) to see real audit entries. This shows which fields are populated.
+
+4. **Draft the policy**: Create an ActivityPolicy YAML with rules for common verbs
+   (create, update, delete, patch). Reference [cel-functions.md](skills/author-policy/reference/cel-functions.md)
+   for CEL variable names and the `link()` function.
+
+5. **Preview**: Call `preview_activity_policy` with the drafted policy spec and
+   `autoFetch: { limit: 20, timeRange: "24h", sources: "both" }` to test it.
+
+6. **Iterate**: Based on preview results, fix any CEL errors, improve summary
+   text, and add rules for unmatched inputs. Re-preview until satisfied.
+
+7. **Save**: Write the finalized policy YAML to the user's specified location.
+
+## CEL Quick Reference
+
+### Audit Rule Variables
+- `audit` — Full audit log map: `audit.verb`, `audit.objectRef.name`, `audit.objectRef.namespace`, `audit.objectRef.apiGroup`, `audit.responseStatus.code`
+- `actor` — Username string (extracted from `audit.user.username`)
+- `actorRef` — Map with `type` ("user", "serviceaccount", "system", or "unknown") and `name`
+- `kind` — Resource name string, plural lowercase (from `audit.objectRef.resource`, e.g., "httpproxies", "pods")
+
+### Event Rule Variables
+- `event` — Full Kubernetes Event: `event.reason`, `event.type`, `event.note`, `event.regarding`
+- `actor` — Controller name (from `event.reportingController` or `event.source.component`)
+- `actorRef` — Map with `type` ("controller") and `name`
+
+### Functions
+- `link(displayText, resourceRef)` — Creates a clickable resource reference
+
+### Summary Template Syntax
+Use `{{ CEL expression }}` delimiters. Expressions must return strings.
+
+### Common Patterns
+
+**Match expressions:**
+```
+audit.verb == 'create'
+audit.verb in ['update', 'patch']
+event.reason == 'Programmed'
+event.type == 'Warning'
+true                              # fallback rule (must be last)
+```
+
+**Summary expressions:**
+```
+{{ actor }} created {{ link(kind + ' ' + audit.objectRef.name, audit.responseObject) }}
+{{ actor }} deleted {{ kind }} {{ audit.objectRef.name }} in namespace {{ audit.objectRef.namespace }}
+{{ actor }} performed {{ audit.verb }} on {{ kind }} {{ audit.objectRef.name }}
+```
+
+## Best Practices
+
+- Rules are evaluated **in order** — first match wins. Put specific rules before general ones.
+- Always include a **fallback rule** with match `"true"` as the last rule.
+- Use `link()` to make resource names clickable in the UI.
+- Name rules descriptively (e.g., "create-resource", "scale-replicas").
+- Test with `preview_activity_policy` before applying to the cluster.
+
+## Constraints
+
+- You have **no Bash access**. You cannot `kubectl apply` policies — only write YAML files.
+- Always preview policies before declaring them ready.
+- If CEL errors occur during preview, explain the error and suggest a fix.

--- a/plugins/milo-activity/skills/activity-summary/SKILL.md
+++ b/plugins/milo-activity/skills/activity-summary/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: activity-summary
+description: >
+  Generate a summary of recent cluster activity for handoffs, standups,
+  or status updates. Use when the user asks for a status update, what
+  happened recently, needs a summary for a handoff, or says "catch me up".
+model: haiku
+---
+
+Generate a concise activity summary.
+
+1. Call `summarize_recent_activity` for the requested time range.
+   Default to "last 24 hours" for handoffs/standups, "last 1 hour" for quick checks.
+
+2. Call `get_activity_timeline` with an appropriate bucket size
+   (e.g., "1h" for 24h range, "5m" for 1h range) to show activity distribution.
+
+3. If the user wants to know if current activity is unusual, call
+   `compare_activity_periods` comparing the current window to the same
+   duration immediately before.
+
+4. Format output as a concise status report:
+   - **Highlights**: Top 3-5 notable changes
+   - **Top actors**: Who was most active
+   - **Most changed resources**: Which resource kinds saw the most activity
+   - **Failures**: Any failed operations (if any)
+   - **Activity pattern**: Whether activity is normal, elevated, or reduced
+
+$ARGUMENTS

--- a/plugins/milo-activity/skills/audit-user/SKILL.md
+++ b/plugins/milo-activity/skills/audit-user/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: audit-user
+description: >
+  Audit a specific user's recent actions across all resources. Use when the
+  user asks about what someone did, requests a user activity report, or needs
+  to review actions for security or compliance purposes.
+context: fork
+agent: incident-investigator
+---
+
+Audit the activity of the following user:
+
+$ARGUMENTS
+
+## Your Task
+
+1. Call `get_user_activity_summary` with `includeDetails: true` for this user
+   to get an overview and recent activities.
+
+2. Call `find_failed_operations` filtered to this user to identify any
+   permission issues or errors they encountered.
+
+3. Call `get_activity_facets` for Activity resource fields `spec.resource.kind`
+   and `spec.resource.namespace` filtered to this user to understand their
+   scope of changes.
+
+4. Present a structured report:
+   - **Summary**: Total actions, time range covered
+   - **Resources touched**: Which kinds and namespaces
+   - **Actions by type**: Creates, updates, deletes
+   - **Failures**: Any failed operations with status codes
+   - **Timeline**: Chronological list of significant actions

--- a/plugins/milo-activity/skills/author-policy/SKILL.md
+++ b/plugins/milo-activity/skills/author-policy/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: author-policy
+description: >
+  Create or edit an ActivityPolicy that translates audit logs or events into
+  human-readable activity summaries. Use when the user mentions ActivityPolicy,
+  wants to create translation rules, asks about CEL expressions for activity,
+  or wants to define how changes appear in the activity timeline.
+---
+
+Help the user create or edit an ActivityPolicy.
+
+For detailed CEL variable definitions and function reference, see
+[cel-functions.md](reference/cel-functions.md).
+
+## Workflow
+
+1. **Identify the target resource**: What API group and kind should this policy cover?
+   Check existing policies with `list_activity_policies`.
+
+2. **Discover available data**: Use `get_audit_log_facets` and `get_event_facets`
+   to see what data exists for the target resource.
+
+3. **Fetch samples**: Use `query_audit_logs` (limit 5) filtered to the target
+   resource to see real field values.
+
+4. **Draft the policy**: Create ActivityPolicy YAML with rules for common verbs.
+   Use the CEL reference for variable names and template syntax.
+
+5. **Preview**: Call `preview_activity_policy` with `autoFetch` enabled to test.
+
+6. **Iterate**: Fix errors, improve summaries, add rules for unmatched inputs.
+
+7. **Save**: Write the final YAML file.
+
+## Quick Example
+
+```yaml
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: example-resource-policy
+spec:
+  resource:
+    apiGroup: example.datumapis.com
+    kind: ExampleResource
+  auditRules:
+    - name: create
+      match: "audit.verb == 'create'"
+      summary: "{{ actor }} created {{ link(kind + ' ' + audit.objectRef.name, audit.responseObject) }}"
+    - name: update
+      match: "audit.verb in ['update', 'patch']"
+      summary: "{{ actor }} updated {{ link(kind + ' ' + audit.objectRef.name, audit.responseObject) }}"
+    - name: delete
+      match: "audit.verb == 'delete'"
+      summary: "{{ actor }} deleted {{ kind }} {{ audit.objectRef.name }}"
+    - name: fallback
+      match: "true"
+      summary: "{{ actor }} performed {{ audit.verb }} on {{ kind }} {{ audit.objectRef.name }}"
+```
+
+$ARGUMENTS

--- a/plugins/milo-activity/skills/author-policy/reference/cel-functions.md
+++ b/plugins/milo-activity/skills/author-policy/reference/cel-functions.md
@@ -1,0 +1,92 @@
+# CEL Reference for ActivityPolicy Rules
+
+## Audit Rule Variables
+
+### `audit` (map)
+The full audit log entry. Key fields:
+- `audit.verb` — string: "create", "update", "patch", "delete", "get", "list", "watch"
+- `audit.objectRef.resource` — string: resource type (e.g., "httpproxies")
+- `audit.objectRef.name` — string: resource name
+- `audit.objectRef.namespace` — string: namespace
+- `audit.objectRef.apiGroup` — string: API group
+- `audit.user.username` — string: authenticated username
+- `audit.responseStatus.code` — int: HTTP status code
+- `audit.responseObject` — map: the response resource (for create/get)
+- `audit.requestObject` — map: the request body (for create/update/patch)
+
+### `actor` (string)
+Convenience variable: the username extracted from `audit.user.username`.
+
+### `actorRef` (map)
+Reference to the actor with fields:
+- `actorRef.type` — string: "user", "serviceaccount", "system", or "unknown"
+- `actorRef.name` — string: the actor's name
+
+### `kind` (string)
+The plural resource name (lowercase) extracted from `audit.objectRef.resource`.
+For example: `"httpproxies"`, `"pods"`, `"deployments"` — not the PascalCase Kind like `"HTTPProxy"`.
+
+## Event Rule Variables
+
+### `event` (map)
+The full Kubernetes Event. Key fields:
+- `event.reason` — string: e.g., "Programmed", "FailedCreate", "ScalingReplicaSet"
+- `event.type` — string: "Normal" or "Warning"
+- `event.note` — string: human-readable event message
+- `event.regarding.name` — string: resource name the event is about
+- `event.regarding.namespace` — string: namespace
+- `event.regarding.kind` — string: resource kind
+- `event.reportingController` — string: controller that reported the event
+- `event.source.component` — string: source component name
+
+### `actor` (string)
+Controller name extracted from `event.reportingController` or `event.source.component`.
+
+### `actorRef` (map)
+Reference to the actor:
+- `actorRef.type` — always "controller"
+- `actorRef.name` — the controller name
+
+## Functions
+
+### `link(displayText string, resourceRef map) -> string`
+Creates a clickable resource reference in the activity UI.
+
+**Parameters:**
+- `displayText` — text to display (e.g., `"HTTPProxy my-proxy"`)
+- `resourceRef` — map identifying the resource (typically `audit.responseObject` or `audit.requestObject`)
+
+**Example:**
+```
+link(kind + ' ' + audit.objectRef.name, audit.responseObject)
+```
+
+## Summary Template Syntax
+
+Summaries use `{{ CEL expression }}` delimiters. Each expression must return a string.
+Multiple expressions can appear in one summary.
+
+**Examples:**
+```
+{{ actor }} created {{ link(kind + ' ' + audit.objectRef.name, audit.responseObject) }}
+{{ actor }} updated {{ kind }} {{ audit.objectRef.name }} in namespace {{ audit.objectRef.namespace }}
+{{ actor }} performed {{ audit.verb }} on {{ kind }} {{ audit.objectRef.name }}
+```
+
+## Common Match Patterns
+
+| Pattern | Description |
+|---------|-------------|
+| `audit.verb == 'create'` | Matches resource creation |
+| `audit.verb in ['update', 'patch']` | Matches modifications |
+| `audit.verb == 'delete'` | Matches deletion |
+| `event.reason == 'Programmed'` | Matches specific event reason |
+| `event.type == 'Warning'` | Matches warning events |
+| `event.reason.startsWith('Failed')` | Matches failure events |
+| `true` | Fallback — matches everything (must be last rule) |
+
+## Rule Evaluation
+
+- Rules are evaluated **in order** — first match wins
+- Always include a **fallback rule** with `match: "true"` as the last rule
+- Name rules descriptively for debugging (e.g., "create-resource", "scale-replicas")

--- a/plugins/milo-activity/skills/investigate-incident/SKILL.md
+++ b/plugins/milo-activity/skills/investigate-incident/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: investigate-incident
+description: >
+  Investigate a cluster incident by systematically checking recent activity,
+  failed operations, and resource changes. Use when the user reports something
+  is broken, asks "what happened", mentions an outage, incident, or error,
+  or wants to understand recent cluster changes.
+context: fork
+agent: incident-investigator
+---
+
+Investigate the following incident:
+
+$ARGUMENTS
+
+Start by establishing the time window and scope from the description above.
+If no time window is specified, default to the last 1 hour.
+If no namespace or resource is specified, search across all namespaces.
+
+Follow your investigation methodology and return a structured report with
+timeline, key actors, failures, root cause hypothesis, and next steps.

--- a/plugins/milo-activity/skills/investigate/SKILL.md
+++ b/plugins/milo-activity/skills/investigate/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: investigate
+description: Start an incident investigation with a description of the issue
+disable-model-invocation: true
+argument-hint: "<description of the incident>"
+context: fork
+agent: incident-investigator
+---
+
+<!-- Manual slash-command entry point: /milo-activity:investigate <description>
+     The investigate-incident skill handles auto-invocation for the same workflow. -->
+
+Investigate the following incident:
+
+$ARGUMENTS
+
+Start by establishing the time window and scope from the description above.
+If no time window is specified, default to the last 1 hour.
+If no namespace or resource is specified, search across all namespaces.
+
+Follow your investigation methodology and return a structured report with
+timeline, key actors, failures, root cause hypothesis, and next steps.

--- a/plugins/milo-activity/skills/preview-policy/SKILL.md
+++ b/plugins/milo-activity/skills/preview-policy/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: preview-policy
+description: >
+  Test an ActivityPolicy against sample data and iterate on its rules.
+  Use when the user wants to test, debug, or validate an existing or
+  in-progress ActivityPolicy, or when they say "preview this policy"
+  or "test this policy".
+---
+
+Test and validate an ActivityPolicy.
+
+## Workflow
+
+1. **Load the policy**: Read the ActivityPolicy YAML from the file or conversation
+   context provided by the user.
+
+2. **Run preview**: Call `preview_activity_policy` with the policy spec and
+   `autoFetch: { limit: 20, timeRange: "24h", sources: "both" }` to test
+   against real data.
+
+3. **Analyze results**: For each input in the preview results:
+   - Did it match a rule? Which one?
+   - Is the generated summary accurate and readable?
+   - Are there CEL evaluation errors?
+
+4. **Report coverage**:
+   - Rules that matched and their hit counts
+   - Inputs that were **unmatched** (gaps in rule coverage)
+   - Any CEL errors with explanations and suggested fixes
+
+5. **Suggest improvements**: If rules have errors or many inputs are unmatched,
+   propose new or modified rules.
+
+6. **Re-preview**: After making changes, preview again to verify fixes.
+
+$ARGUMENTS

--- a/plugins/milo-activity/skills/status/SKILL.md
+++ b/plugins/milo-activity/skills/status/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: status
+description: Quick summary of recent cluster activity (last hour)
+disable-model-invocation: true
+argument-hint: "[time-range]"
+model: haiku
+---
+
+Show a quick activity status for the cluster.
+
+1. Call `summarize_recent_activity` with `startTime` set to "$ARGUMENTS"
+   (default: "now-1h" if no argument provided).
+
+2. If there are any failed operations in the summary, call
+   `find_failed_operations` for the same time range (limit 5).
+
+3. Format as a brief status block:
+   - Total activities in the period
+   - Top 3 actors and what they did
+   - Top 3 most-changed resource kinds
+   - Any failures (with status codes)
+
+Keep it concise — this is a quick check, not a deep investigation.


### PR DESCRIPTION
## Summary

Adds the `milo-activity` plugin to the marketplace, providing Claude Code skills and agents for the Milo Activity service. The plugin teaches Claude how to investigate incidents, audit user actions, and author ActivityPolicies using the Activity MCP server's 14 tools.

### Components

- **2 agents**: `incident-investigator` (read-only, maxTurns: 15) and `policy-author` (write access, no Bash, maxTurns: 20)
- **7 skills**: `investigate-incident`, `investigate` (manual), `audit-user`, `author-policy`, `preview-policy`, `activity-summary`, `status` (manual)
- **CEL reference**: Supporting file documenting all CEL variables, functions, and match patterns for ActivityPolicy authoring

### Design decisions

- Investigation skills use `context: fork` to isolate high-volume tool output from parent context
- Policy authoring skills run inline to preserve conversation history for iterative refinement
- Summary skills use `model: haiku` for cheaper, faster execution
- MCP server is NOT bundled — users configure the `activity` MCP server separately

## Test plan

- [x] Load plugin locally with `claude --plugin-dir plugins/milo-activity` and verify all components register
- [x] Test `/milo-activity:status` and `/milo-activity:investigate` slash commands
- [x] Verify `investigate-incident` skill auto-invokes on "what happened in the cluster"
- [x] Verify `author-policy` skill auto-invokes on "create an ActivityPolicy"
- [x] Verify `activity-summary` skill auto-invokes on "catch me up"
- [x] Confirm incident-investigator agent is read-only (cannot Write/Edit)
- [x] Confirm policy-author agent cannot use Bash
- [x] Validate marketplace.json with `claude plugin validate .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Relates to https://github.com/datum-cloud/enhancements/issues/469