### PR TITLE
feat(datum-platform): add operational reviewer agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes to the Datum Cloud Claude Code plugins.
 
+## [1.6.0] - 2026-04-12
+
+### Added
+
+- **Operational review skill** (`operational-review`) — Guides the SRE agent through producing weekly traffic and latency ops review reports for the global Envoy edge ingress. Covers VictoriaMetrics queries for RPS and latency (P50/P90/P95) globally and per-POP, anomaly detection thresholds, and publishing structured reports as pull requests to `datum-cloud/engineering`.
+
 ## [1.5.0] - 2026-02-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A marketplace for Claude Code plugins providing platform engineering tools and a
 
 | Plugin | Description | Version |
 |--------|-------------|---------|
-| [datum-platform](./plugins/datum-platform/) | Kubernetes platform engineering automation with aggregated API servers, controller patterns, and GitOps deployment | 1.5.0 |
+| [datum-platform](./plugins/datum-platform/) | Kubernetes platform engineering automation with aggregated API servers, controller patterns, and GitOps deployment | 1.6.0 |
 | [datum-gtm](./plugins/datum-gtm/) | Go-to-market automation with commercial strategy, product discovery, and customer support | 1.0.0 |
 | [milo-activity](./plugins/milo-activity/) | Query audit logs, investigate incidents, and author ActivityPolicies using the Milo Activity service | 1.0.0 |
 

--- a/plugins/datum-platform/.claude-plugin/plugin.json
+++ b/plugins/datum-platform/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datum-platform",
   "description": "Kubernetes platform engineering automation with aggregated API servers, controller patterns, GitOps deployment, and platform capabilities",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": {
     "name": "Datum Cloud",
     "url": "https://github.com/datum-cloud"

--- a/plugins/datum-platform/agents/operational-reviewer.md
+++ b/plugins/datum-platform/agents/operational-reviewer.md
@@ -1,0 +1,104 @@
+---
+name: operational-reviewer
+description: >
+  Use when asked to produce, publish, or update a weekly operational report for
+  the Datum AI Edge. Triggered by phrases like "ops review", "traffic report",
+  "weekly report", "latency analysis", "POP report", "consumer breakdown",
+  "error rate report", or "provisioning report". Covers edge traffic, top
+  consumers, error codes by API group, and control plane provisioning health.
+  Read-only on metrics; writes reports to datum-cloud/engineering.
+tools: Read, Write, Edit, Bash, Grep, Glob
+model: sonnet
+---
+
+# Operational Reviewer Agent
+
+You produce weekly operational reports for the Datum AI Edge. Source data comes
+from VictoriaMetrics prod via the MCP server; output is a structured Markdown
+report committed to `datum-cloud/engineering` as a pull request.
+
+## Scope
+
+Two domains per report:
+
+**Edge Traffic** — requests processed, latency (P50/P90/P95) globally and
+per-POP, top consumers by volume, error codes by API group.
+
+**Control Plane** — AI edges created and active, provisioning performance across
+Karmada (scheduling latency, time-to-ready per member cluster), API server error
+codes by resource group.
+
+## Context Discovery
+
+Before doing any work, read in this order:
+
+1. `operational-review/SKILL.md` — full workflow overview
+2. `operational-review/queries.md` — exact VictoriaMetrics query expressions
+3. `operational-review/report-format.md` — report structure and PR conventions
+
+## Workflow
+
+```
+Query metrics → Analyze → Detect anomalies → Write report → Open PR
+```
+
+See `operational-review/SKILL.md` for the step-by-step breakdown.
+
+## Metrics Source
+
+All queries target:
+
+```
+mcp__datum-infra-prod__victoria-metrics-mcp-server
+```
+
+Before querying new categories (consumers, API groups, Karmada), use `metrics`
+or `label_values` to confirm available metric names and labels. Run all queries
+in parallel. Refer to `queries.md` for exact expressions and step intervals.
+
+## Output
+
+| Attribute | Value |
+|-----------|-------|
+| Repo | `~/src/datum-cloud/engineering` |
+| Path | `reports/traffic/YYYY-MM-DD-datum-traffic.md` |
+| Branch | `ops/traffic-report-YYYY-MM-DD` |
+| PR title | `Ops Review: Weekly traffic report YYYY-MM-DD` |
+
+Refer to `report-format.md` for the full report structure, PR body template,
+and git workflow.
+
+## Anomaly Detection
+
+Flag automatically (thresholds in `queries.md`):
+
+- RPS spikes > 150% of weekly average
+- Per-POP P90 > 300ms; P95 > 500ms
+- Recurring P95 > 500ms 3+ times — mark as persistent issue
+- Latency regime shifts mid-week
+- 5xx error rate > 1% of total requests
+- Karmada scheduling P90 > 5s
+- Propagation P90 > 60s
+- Any sustained binding failure rate
+
+## Known Patterns (Do Not Flag)
+
+- **Bimodal latency**: P50 ~0.35ms vs P90 ~170ms is normal (health checks vs proxied requests)
+- **Control plane dominance**: `prod-infrastructure-control-plane` ~60% of RPS is expected
+- **RPS spike + P50 rise + stable P90**: fast-request spike, not a latency regression
+
+## Incremental Updates
+
+If asked to add data to an existing report:
+
+1. Read the current file
+2. Insert the new section in the correct position (see `report-format.md` for order)
+3. Update the `**Source:**` header line if needed
+4. Commit: `ops: add {section} to traffic report`
+5. Push — the existing PR updates automatically
+
+## Skills to Reference
+
+- `operational-review` — Queries, anomaly thresholds, report format, git workflow
+- `capability-telemetry` — General observability context
+- `fluxcd-deployment` — Correlate latency spikes with deployment timelines

--- a/plugins/datum-platform/agents/operational-reviewer.md
+++ b/plugins/datum-platform/agents/operational-reviewer.md
@@ -35,6 +35,7 @@ Before doing any work, read in this order:
 1. `operational-review/SKILL.md` — full workflow overview
 2. `operational-review/queries.md` — exact VictoriaMetrics query expressions
 3. `operational-review/report-format.md` — report structure and PR conventions
+4. `operational-review/consumer-identity.md` — how to resolve consumer identity from metrics
 
 ## Workflow
 

--- a/plugins/datum-platform/agents/sre.md
+++ b/plugins/datum-platform/agents/sre.md
@@ -421,12 +421,6 @@ kubectl get activities --watch
 kubectl get activities --watch --field-selector spec.resource.namespace=production
 ```
 
-## Operational Reviews
-
-For weekly ops review reports covering global Envoy edge traffic and latency, read
-`operational-review/SKILL.md` before starting. It covers the full workflow: metric queries,
-anomaly detection, per-POP latency analysis, and publishing to `datum-cloud/engineering`.
-
 ## Skills to Reference
 
 - `kustomize-patterns` — Base + components, overlays for local development
@@ -435,5 +429,4 @@ anomaly detection, per-POP latency analysis, and publishing to `datum-cloud/engi
 - `milo-iam` — IAM resource deployment (ProtectedResources, Roles)
 - `capability-telemetry` — Observability setup patterns
 - `capability-activity` — Activity logs for debugging and investigation (see `consuming-timelines.md`)
-- `operational-review` — Weekly traffic and latency ops review reports
 - `user-corrections` — Correction detection and logging

--- a/plugins/datum-platform/agents/sre.md
+++ b/plugins/datum-platform/agents/sre.md
@@ -421,6 +421,12 @@ kubectl get activities --watch
 kubectl get activities --watch --field-selector spec.resource.namespace=production
 ```
 
+## Operational Reviews
+
+For weekly ops review reports covering global Envoy edge traffic and latency, read
+`operational-review/SKILL.md` before starting. It covers the full workflow: metric queries,
+anomaly detection, per-POP latency analysis, and publishing to `datum-cloud/engineering`.
+
 ## Skills to Reference
 
 - `kustomize-patterns` — Base + components, overlays for local development
@@ -429,4 +435,5 @@ kubectl get activities --watch --field-selector spec.resource.namespace=producti
 - `milo-iam` — IAM resource deployment (ProtectedResources, Roles)
 - `capability-telemetry` — Observability setup patterns
 - `capability-activity` — Activity logs for debugging and investigation (see `consuming-timelines.md`)
+- `operational-review` — Weekly traffic and latency ops review reports
 - `user-corrections` — Correction detection and logging

--- a/plugins/datum-platform/skills/operational-review/SKILL.md
+++ b/plugins/datum-platform/skills/operational-review/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: operational-review
+description: Covers producing weekly operational traffic reports for the Datum Cloud global Envoy edge ingress. Use when asked for an ops review, traffic report, or latency analysis across POPs. Guides metric queries, anomaly detection, and publishing to datum-cloud/engineering.
+---
+
+# Operational Review
+
+This skill covers producing and publishing weekly ops review reports covering global Envoy edge
+ingress traffic and latency across all POPs.
+
+## Overview
+
+An operational review covers the past 7 days of production traffic across the 18 global POPs.
+The output is a structured Markdown report committed to `datum-cloud/engineering` as a pull
+request. Source data comes from VictoriaMetrics prod via the MCP server.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `queries.md` | VictoriaMetrics queries for RPS and latency |
+| `report-format.md` | Report structure, section order, and PR conventions |
+
+## Workflow
+
+```
+Query VictoriaMetrics → Analyze → Detect anomalies → Write report → Open PR
+```
+
+### 1. Query metrics
+
+Run all metric queries in parallel. See `queries.md` for the exact expressions.
+
+Collect:
+- **Global RPS** — hourly for 7 days, plus 1m-resolution max for the true peak
+- **POP count** — confirm how many clusters are reporting
+- **Per-POP RPS** — to identify which clusters drive spikes
+- **Global latency P50/P90/P95** — hourly for 7 days
+- **Per-POP latency P50/P90/P95** — 6h resolution for 7 days
+
+### 2. Analyze
+
+From the raw time series, compute:
+
+| Metric | How |
+|--------|-----|
+| Weekly average RPS | Mean of hourly values |
+| Baseline range | Mode band (exclude spikes >2× median) |
+| Peak RPS | True 1m-resolution max |
+| Daily avg RPS | Mean per calendar day (UTC) |
+| Latency weekly median | `statistics.median()` per cluster — more robust than mean for tail metrics |
+| Per-POP latency ranking | Sort by P90 median ascending |
+
+### 3. Detect anomalies
+
+Flag automatically:
+
+- RPS spikes > 150% of weekly average
+- Per-POP P90 > 300ms (threshold for investigation)
+- Per-POP P95 > 500ms
+- Clusters that changed latency regime mid-week (regime shift)
+- Clusters with *recurring* (not one-off) tail spikes — suggests persistent issue
+
+### 4. Write and publish report
+
+- File path: `reports/traffic/YYYY-MM-DD-datum-traffic.md` in `datum-cloud/engineering`
+- Branch: `ops/traffic-report-YYYY-MM-DD`
+- PR title: `Ops Review: Weekly traffic report YYYY-MM-DD`
+- See `report-format.md` for the full report structure
+
+## Infrastructure
+
+- **Metrics source**: VictoriaMetrics prod (`mcp__datum-infra-prod__victoria-metrics-mcp-server`)
+- **Target repo**: `~/src/datum-cloud/engineering`
+- **18 POPs**: 1 control plane + 16 `*-alice` edge POPs + 1 lab cluster
+- **Key metrics**: `envoy_http_downstream_rq_total`, `envoy_http_downstream_rq_time_bucket`
+
+## Known Patterns
+
+### Bimodal latency distribution
+
+The global P50 (~0.35ms edge, ~4ms control plane) vs P90 (~170ms) gap is expected. It reflects
+two distinct traffic classes:
+- **Fast**: health checks, lightweight API calls (~0.35ms)
+- **Slow**: proxied upstream requests (~170ms)
+
+Do not flag this as an anomaly. It is the normal operating state.
+
+### Control plane traffic dominance
+
+`prod-infrastructure-control-plane` typically carries ~60% of total RPS. This is expected — it
+handles all API server traffic. Edge POPs run at ~2–3 RPS baseline.
+
+### RPS spike + P50 rise with stable P90
+
+When the global RPS spikes but P50 rises while P90 holds flat or drops, the spike is composed
+of fast requests (health checks, retries). This is not a latency regression.
+
+### RPS spike + P90/P95 rise
+
+When P90 and P95 rise alongside an RPS spike, investigate the per-POP latency — one POP is
+likely saturated or experiencing network issues.
+
+## Related Skills
+
+- `capability-telemetry` — General observability instrumentation
+- `fluxcd-deployment` — For correlating latency spikes with deployment timelines

--- a/plugins/datum-platform/skills/operational-review/SKILL.md
+++ b/plugins/datum-platform/skills/operational-review/SKILL.md
@@ -33,6 +33,9 @@ Analysis of AI Edge resource lifecycle and provisioning health:
   scheduler latency, per-cluster distribution
 - **Error codes by API group** — webhook admission errors, controller reconcile
   errors, and API server error rates per resource group
+- **Project count and memory pressure** — total project namespaces, week-over-week
+  growth, Kyverno UpdateRequest backlog depth, and admission controller memory
+  utilization vs limit (see infra#2220 for why this matters)
 
 ## Key Files
 

--- a/plugins/datum-platform/skills/operational-review/SKILL.md
+++ b/plugins/datum-platform/skills/operational-review/SKILL.md
@@ -110,7 +110,7 @@ in both the Open Incidents section and the relevant Key Finding.
 
 ### 6. Write and publish report
 
-- File path: `reviews/ai-edge/YYYY-MM-DD-ai-edge-ops-review.md` in `datum-cloud/engineering`
+- File path: `reviews/ai-edge/YYYY-MM-DD-edge-ops-review.md` in `datum-cloud/engineering`
 - Branch: `ops/traffic-report-YYYY-MM-DD`
 - PR title: `Ops Review: Weekly traffic report YYYY-MM-DD`
 - See `report-format.md` for the full report structure

--- a/plugins/datum-platform/skills/operational-review/SKILL.md
+++ b/plugins/datum-platform/skills/operational-review/SKILL.md
@@ -45,7 +45,7 @@ Analysis of AI Edge resource lifecycle and provisioning health:
 ## Workflow
 
 ```
-Query metrics → Analyze → Detect anomalies → Write report → Open PR
+Query metrics + incidents → Analyze → Correlate → Write report → Open PR
 ```
 
 ### 1. Discover available metrics
@@ -89,7 +89,26 @@ From the raw time series, compute:
 
 Flag automatically — see `queries.md` for thresholds.
 
-### 5. Write and publish report
+### 5. Surface relevant incidents
+
+Query GitHub for incidents in `datum-cloud/engineering`:
+
+```bash
+gh issue list --repo datum-cloud/engineering \
+  --label ":incident/issue" \
+  --state all \
+  --json number,title,state,createdAt,closedAt
+```
+
+Filter for AI Edge relevance:
+- **Include**: incidents opened or closed within the report period (±2 days)
+- **Include**: any open incidents touching proxies, edge, routing, Envoy, Karmada, or provisioning
+- **Exclude**: unrelated infrastructure (DNS for non-edge domains, staff portal, auth UI)
+
+Where an incident's timing overlaps a metric anomaly, note the correlation explicitly
+in both the Open Incidents section and the relevant Key Finding.
+
+### 6. Write and publish report
 
 - File path: `reports/traffic/YYYY-MM-DD-datum-traffic.md` in `datum-cloud/engineering`
 - Branch: `ops/traffic-report-YYYY-MM-DD`

--- a/plugins/datum-platform/skills/operational-review/SKILL.md
+++ b/plugins/datum-platform/skills/operational-review/SKILL.md
@@ -1,44 +1,74 @@
 ---
 name: operational-review
-description: Covers producing weekly operational traffic reports for the Datum Cloud global Envoy edge ingress. Use when asked for an ops review, traffic report, or latency analysis across POPs. Guides metric queries, anomaly detection, and publishing to datum-cloud/engineering.
+description: Covers producing weekly operational reports for the Datum AI Edge. Use when asked for an ops review, traffic report, latency analysis, provisioning report, or edge performance summary. Guides metric queries, anomaly detection, and publishing to datum-cloud/engineering.
 ---
 
 # Operational Review
 
-This skill covers producing and publishing weekly ops review reports covering global Envoy edge
-ingress traffic and latency across all POPs.
+This skill covers producing and publishing weekly ops review reports for the
+Datum AI Edge — covering edge traffic performance, consumer patterns, and
+control plane provisioning health.
 
-## Overview
+## Scope
 
-An operational review covers the past 7 days of production traffic across the 18 global POPs.
-The output is a structured Markdown report committed to `datum-cloud/engineering` as a pull
-request. Source data comes from VictoriaMetrics prod via the MCP server.
+An operational review covers two domains:
+
+### Edge Traffic
+
+Analysis of request traffic flowing through the Datum AI Edge:
+
+- **Request volume** — total requests processed, RPS trends, daily averages, peak
+- **Latency** — P50/P90/P95 globally and per POP
+- **Performance** — per-POP throughput and latency rankings
+- **Top consumers** — highest-traffic tenants/namespaces, usage patterns
+- **Error codes by API group** — 4xx/5xx breakdown per API group to surface
+  degraded or misconfigured routes
+
+### Control Plane Traffic
+
+Analysis of AI Edge resource lifecycle and provisioning health:
+
+- **AI edges created** — creation rate and total count over the review period
+- **Provisioning performance** — time-to-ready across Karmada propagation,
+  scheduler latency, per-cluster distribution
+- **Error codes by API group** — webhook admission errors, controller reconcile
+  errors, and API server error rates per resource group
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `queries.md` | VictoriaMetrics queries for RPS and latency |
+| `queries.md` | VictoriaMetrics queries for all metric categories |
 | `report-format.md` | Report structure, section order, and PR conventions |
 
 ## Workflow
 
 ```
-Query VictoriaMetrics → Analyze → Detect anomalies → Write report → Open PR
+Query metrics → Analyze → Detect anomalies → Write report → Open PR
 ```
 
-### 1. Query metrics
+### 1. Discover available metrics
 
-Run all metric queries in parallel. See `queries.md` for the exact expressions.
+Before querying, confirm what labels are available for consumer/tenant
+segmentation and API group breakdowns. Use:
+
+```
+victoria-metrics metrics (search: "envoy_http", "karmada", "apiserver_request")
+victoria-metrics label_values (label: "cluster", "namespace", "resource", "group")
+```
+
+### 2. Query metrics
+
+Run all queries in parallel. See `queries.md` for the exact expressions.
 
 Collect:
-- **Global RPS** — hourly for 7 days, plus 1m-resolution max for the true peak
-- **POP count** — confirm how many clusters are reporting
-- **Per-POP RPS** — to identify which clusters drive spikes
-- **Global latency P50/P90/P95** — hourly for 7 days
-- **Per-POP latency P50/P90/P95** — 6h resolution for 7 days
+- **Edge traffic** — RPS (hourly + 1m peak), per-POP RPS, latency P50/P90/P95
+  (hourly global, 6h per-POP), top consumers by request volume, error rate by
+  API group
+- **Control plane** — AI edge creation rate, time-to-ready distribution,
+  Karmada propagation latency, API server error rate by resource group
 
-### 2. Analyze
+### 3. Analyze
 
 From the raw time series, compute:
 
@@ -48,20 +78,17 @@ From the raw time series, compute:
 | Baseline range | Mode band (exclude spikes >2× median) |
 | Peak RPS | True 1m-resolution max |
 | Daily avg RPS | Mean per calendar day (UTC) |
-| Latency weekly median | `statistics.median()` per cluster — more robust than mean for tail metrics |
+| Latency weekly median | `statistics.median()` per cluster — more robust than mean |
 | Per-POP latency ranking | Sort by P90 median ascending |
+| Top consumers | Sum by tenant/namespace, sort descending, take top 10 |
+| Error rate by group | Total errors / total requests per API group |
+| Provisioning P90 | Histogram quantile for time-to-ready |
 
-### 3. Detect anomalies
+### 4. Detect anomalies
 
-Flag automatically:
+Flag automatically — see `queries.md` for thresholds.
 
-- RPS spikes > 150% of weekly average
-- Per-POP P90 > 300ms (threshold for investigation)
-- Per-POP P95 > 500ms
-- Clusters that changed latency regime mid-week (regime shift)
-- Clusters with *recurring* (not one-off) tail spikes — suggests persistent issue
-
-### 4. Write and publish report
+### 5. Write and publish report
 
 - File path: `reports/traffic/YYYY-MM-DD-datum-traffic.md` in `datum-cloud/engineering`
 - Branch: `ops/traffic-report-YYYY-MM-DD`
@@ -72,8 +99,8 @@ Flag automatically:
 
 - **Metrics source**: VictoriaMetrics prod (`mcp__datum-infra-prod__victoria-metrics-mcp-server`)
 - **Target repo**: `~/src/datum-cloud/engineering`
-- **18 POPs**: 1 control plane + 16 `*-alice` edge POPs + 1 lab cluster
-- **Key metrics**: `envoy_http_downstream_rq_total`, `envoy_http_downstream_rq_time_bucket`
+- **Key edge metrics**: `envoy_http_downstream_rq_total`, `envoy_http_downstream_rq_time_bucket`
+- **Key control plane metrics**: `apiserver_request_total`, Karmada scheduler/propagation metrics
 
 ## Known Patterns
 
@@ -84,24 +111,21 @@ two distinct traffic classes:
 - **Fast**: health checks, lightweight API calls (~0.35ms)
 - **Slow**: proxied upstream requests (~170ms)
 
-Do not flag this as an anomaly. It is the normal operating state.
+Do not flag as an anomaly.
 
 ### Control plane traffic dominance
 
-`prod-infrastructure-control-plane` typically carries ~60% of total RPS. This is expected — it
-handles all API server traffic. Edge POPs run at ~2–3 RPS baseline.
+`prod-infrastructure-control-plane` typically carries ~60% of total RPS. This is expected.
 
 ### RPS spike + P50 rise with stable P90
 
-When the global RPS spikes but P50 rises while P90 holds flat or drops, the spike is composed
-of fast requests (health checks, retries). This is not a latency regression.
+Spike composed of fast requests (health checks, retries). Not a latency regression.
 
 ### RPS spike + P90/P95 rise
 
-When P90 and P95 rise alongside an RPS spike, investigate the per-POP latency — one POP is
-likely saturated or experiencing network issues.
+Investigate per-POP latency — one POP is likely saturated or experiencing network issues.
 
 ## Related Skills
 
 - `capability-telemetry` — General observability instrumentation
-- `fluxcd-deployment` — For correlating latency spikes with deployment timelines
+- `fluxcd-deployment` — Correlate latency spikes with deployment timelines

--- a/plugins/datum-platform/skills/operational-review/SKILL.md
+++ b/plugins/datum-platform/skills/operational-review/SKILL.md
@@ -110,7 +110,7 @@ in both the Open Incidents section and the relevant Key Finding.
 
 ### 6. Write and publish report
 
-- File path: `reports/traffic/YYYY-MM-DD-datum-traffic.md` in `datum-cloud/engineering`
+- File path: `reviews/ai-edge/YYYY-MM-DD-ai-edge-ops-review.md` in `datum-cloud/engineering`
 - Branch: `ops/traffic-report-YYYY-MM-DD`
 - PR title: `Ops Review: Weekly traffic report YYYY-MM-DD`
 - See `report-format.md` for the full report structure

--- a/plugins/datum-platform/skills/operational-review/SKILL.md
+++ b/plugins/datum-platform/skills/operational-review/SKILL.md
@@ -40,6 +40,7 @@ Analysis of AI Edge resource lifecycle and provisioning health:
 |------|---------|
 | `queries.md` | VictoriaMetrics queries for all metric categories |
 | `report-format.md` | Report structure, section order, and PR conventions |
+| `consumer-identity.md` | How to map identity to resources — what works today, what needs platform work |
 
 ## Workflow
 

--- a/plugins/datum-platform/skills/operational-review/consumer-identity.md
+++ b/plugins/datum-platform/skills/operational-review/consumer-identity.md
@@ -1,161 +1,162 @@
 # Consumer Identity Mapping
 
-This document covers how to get per-consumer breakdowns in operational reports and
-what work is needed to close the gaps.
+This document covers how to get per-consumer breakdowns in operational reports.
 
-## Current State
+## Summary
 
-| Layer | Consumer identity available? | Source |
-|-------|------------------------------|--------|
-| Control plane (API server) | **Yes** | `apiserver_request_total{namespace=...}` + `ProjectControlPlane` |
-| Edge traffic (Envoy) | **No** | Envoy metrics carry only infra namespace labels |
-| Karmada provisioning | **Partial** | Binding count is global; no per-project breakdown |
+| Layer | Consumer identity available? | Metric | Join |
+|-------|------------------------------|--------|------|
+| Edge traffic (per-route) | **Yes** | `envoy_cluster_upstream_rq_*` | `httproute_namespace` → `kube_namespace_labels` |
+| Edge traffic (per-gateway) | **Yes** | `envoy_vhost_vcluster_upstream_rq_*` | `envoy_virtual_host` → `datum_cloud_networking_gateway_info` |
+| Control plane (API server) | **Yes** | `apiserver_request_total` | `namespace` → `kube_namespace_labels` |
+| Karmada provisioning | **Partial** | Binding count global; new project count via Kubernetes MCP |
 
----
-
-## Control Plane: What Works Today
-
-Each Datum project gets a dedicated Kubernetes namespace. The namespace name is the
-project name and maps directly to `ProjectControlPlane.metadata.name`.
-
-### Step 1 — Query per-namespace API activity
-
-```
-topk(10, sum by (namespace) (rate(apiserver_request_total[5m])))
-```
-
-Filter system namespaces:
-```
-topk(10, sum by (namespace) (
-  rate(apiserver_request_total{
-    namespace!~"kube-.*|flux-system|cert-manager|.*-gateway.*|.*-system|monitoring"
-  }[5m])
-))
-```
-
-### Step 2 — Resolve namespace → owner via Kubernetes MCP
-
-```python
-get_kubernetes_resources(
-  apiVersion="infrastructure.miloapis.com/v1alpha1",
-  kind="ProjectControlPlane"
-)
-```
-
-Each resource yields:
-```yaml
-metadata:
-  name: <project-name>          # matches namespace in metrics
-  labels:
-    resourcemanager.miloapis.com/project-name: <project-name>
-  annotations:
-    resourcemanager.miloapis.com/owner-name: <org-name>
-```
-
-Join on `namespace == metadata.name` to build:
-
-| Owner | Project | Avg RPS | Error rate |
-|-------|---------|--------:|----------:|
-| org-abc | project-xyz | 1.2 | 0.3% |
+**Do not use** `envoy_http_downstream_rq_total` for consumer analysis — it is the global listener
+metric and carries no consumer identity (only infra namespace labels).
 
 ---
 
-## Edge Traffic: The Gap and How to Close It
+## Edge Traffic: Per-Route Consumer Breakdown (primary approach)
 
-Envoy processes all inbound HTTPS requests but doesn't expose per-tenant metrics because
-JWT claims and project ID headers are not extracted as stat tags.
+Each consumer's HTTPProxy creates an HTTPRoute in a project namespace (`ns-{uuid}`). The edge
+Envoy labels upstream cluster metrics with that namespace, enabling per-consumer queries.
 
-### Option A — Envoy stat tag extraction (recommended)
-
-Configure the `EnvoyProxy` resource to extract a request header or JWT claim as a
-metric label. If every authenticated request carries an `x-project-id` header:
-
-```yaml
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: EnvoyProxy
-metadata:
-  name: datum-gateway
-spec:
-  telemetry:
-    metrics:
-      sinks:
-        - type: OpenTelemetry
-          openTelemetry:
-            host: otel-collector.monitoring.svc
-            port: 4317
-  # Request header extraction for stat tags (requires Envoy stats_matcher or
-  # WASM extension — consult Envoy Gateway docs for the current supported approach)
-```
-
-Once a `project_id` label is propagated, the consumer query becomes:
+### Step 1 — Query per-project traffic
 
 ```
-topk(10, sum by (project_id) (rate(envoy_http_downstream_rq_total[5m])))
-```
-
-### Option B — AIGatewayRoute per-route metrics
-
-`aigateway.envoyproxy.io/AIGatewayRoute` CRDs are registered on the cluster but no
-resources are deployed yet. When routes are created per-consumer (one route per project
-or per AI service), Envoy will emit per-route stats that can be broken down by route name.
-
-The closest existing label is `envoy_http_conn_manager_prefix`. Confirmed current values:
-`http-80`, `https-443`, `aigateway-mcp-backend-listener-http`, `admin`, `eg-ready-http`,
-`eg-stats-http` — all infrastructure listeners, no per-consumer routes.
-
-The agent should check for `AIGatewayRoute` resources at review time:
-
-```python
-get_kubernetes_resources(
-  apiVersion="aigateway.envoyproxy.io/v1alpha1",
-  kind="AIGatewayRoute"
+topk(10,
+  sum by (httproute_namespace) (
+    rate(envoy_cluster_upstream_rq_total{httproute_namespace=~"ns-.*"}[5m])
+  )
 )
 ```
 
-If resources exist, query:
+- `step: 1d` for weekly trend; `step: 1h` for daily pattern
+- Filter `httproute_namespace=~"ns-.*"` to exclude non-project routes
+
+### Step 2 — Resolve namespace → project name
+
+Join with `kube_namespace_labels` to get the project control plane cluster name, then extract
+the project name from it:
+
 ```
-topk(10, sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_total[5m])))
+label_replace(
+  sum by (httproute_namespace) (
+    rate(envoy_cluster_upstream_rq_total{httproute_namespace=~"ns-.*"}[5m])
+  ) * on (httproute_namespace) group_left(label_meta_datumapis_com_upstream_cluster_name)
+    kube_namespace_labels{label_meta_datumapis_com_upstream_cluster_name!=""},
+  "project_name", "$1",
+  "label_meta_datumapis_com_upstream_cluster_name", "cluster-_(.*)"
+)
 ```
 
-and correlate `conn_manager_prefix` values with route names from the Kubernetes query.
+- Join key: `httproute_namespace` == `namespace` on `kube_namespace_labels`
+- `label_meta_datumapis_com_upstream_cluster_name` = `cluster-_{project_name}`
+- Regex `cluster-_(.*)` extracts the project name
 
-### Option C — Activity system (actor identity)
+### Step 3 — Error codes by project
 
-The Activity system records every API operation with actor identity. If the Activity
-service is queryable (check for `activity.miloapis.com` resources or a dedicated
-VictoriaMetrics metric), it provides per-user/per-project request counts with full
-identity context — at higher query cost than Envoy metrics.
+```
+label_replace(
+  sum by (httproute_namespace, envoy_response_code) (
+    rate(envoy_cluster_upstream_rq_xx{httproute_namespace=~"ns-.*"}[5m])
+  ) * on (httproute_namespace) group_left(label_meta_datumapis_com_upstream_cluster_name)
+    kube_namespace_labels{label_meta_datumapis_com_upstream_cluster_name!=""},
+  "project_name", "$1",
+  "label_meta_datumapis_com_upstream_cluster_name", "cluster-_(.*)"
+)
+```
+
+### Step 4 — Latency P90 by project
+
+```
+label_replace(
+  histogram_quantile(0.90,
+    sum by (httproute_namespace, le) (
+      rate(envoy_cluster_upstream_rq_time_bucket{httproute_namespace=~"ns-.*"}[5m])
+    ) * on (httproute_namespace) group_left(label_meta_datumapis_com_upstream_cluster_name)
+      kube_namespace_labels{label_meta_datumapis_com_upstream_cluster_name!=""}
+  ),
+  "project_name", "$1",
+  "label_meta_datumapis_com_upstream_cluster_name", "cluster-_(.*)"
+)
+```
+
+---
+
+## Edge Traffic: Per-Gateway Breakdown (secondary)
+
+Each gateway's virtual host appears in `envoy_vhost_vcluster_upstream_rq_*` with
+`envoy_virtual_host` = `{gateway_uid_no_dashes}_datumproxy_net`. Join with
+`datum_cloud_networking_gateway_info` to resolve project:
+
+```
+label_replace(
+  sum by (gateway_uid) (
+    label_replace(
+      envoy_vhost_vcluster_upstream_rq_total,
+      "gateway_uid", "$1", "envoy_virtual_host", "([a-f0-9]+)_datumproxy_net"
+    )
+  ) * on (gateway_uid) group_left(resourcemanager_datumapis_com_project_name)
+    label_replace(
+      datum_cloud_networking_gateway_info,
+      "gateway_uid", "$1$2$3$4$5", "uid",
+      "([a-f0-9]+)-([a-f0-9]+)-([a-f0-9]+)-([a-f0-9]+)-([a-f0-9]+)"
+    ),
+  "project_name", "$1", "resourcemanager_datumapis_com_project_name", "(.*)"
+)
+```
+
+The per-route approach (Step 1–4 above) is simpler and more reliable. Use per-gateway only
+when you need gateway-level aggregation.
+
+---
+
+## Context: Recording Rule Pipeline
+
+`apps/datum-cloud-telemetry-system/base/kcl/networking.k8s.io.k` defines VMRules that are
+designed to produce pre-enriched versions of `envoy_cluster_upstream_rq_*` and
+`envoy_vhost_vcluster_upstream_rq_*` with `resourcemanager_datumapis_com_project_name` labels.
+These enriched series are not currently present in VictoriaMetrics (confirmed Apr 15, 2026).
+Until they exist, use the explicit join queries above.
+
+---
+
+## Control Plane: Per-Project API Activity
+
+```
+topk(10,
+  sum by (namespace) (
+    rate(apiserver_request_total{namespace=~"ns-.*"}[5m])
+  ) * on (namespace) group_left(label_meta_datumapis_com_upstream_cluster_name)
+    kube_namespace_labels{label_meta_datumapis_com_upstream_cluster_name!=""}
+)
+```
+
+Same join approach as edge traffic.
 
 ---
 
 ## Karmada: Per-Project Provisioning
 
-Karmada scheduler metrics (`karmada_scheduler_schedule_attempts_total`) are currently
-global — no project or namespace label is present.
-
-To get per-project provisioning counts, use the Kubernetes MCP to list
-`ProjectControlPlane` resources with their `creationTimestamp` and filter by the
-reporting period:
+Karmada scheduler metrics are global — no per-project breakdown. Use the Kubernetes MCP to
+count `ProjectControlPlane` resources with `creationTimestamp` within the report period:
 
 ```python
 get_kubernetes_resources(
   apiVersion="infrastructure.miloapis.com/v1alpha1",
   kind="ProjectControlPlane"
 )
-# Filter: creationTimestamp within report period
-# Group by: annotations["resourcemanager.miloapis.com/owner-name"]
+# Count total; filter creationTimestamp within period for new projects this week
 ```
-
-This gives a count of new projects created per owner during the week, which is a
-reasonable proxy for provisioning activity until per-project Karmada metrics are available.
 
 ---
 
-## Summary: What the Agent Should Do Each Week
+## Report Table Format
 
-| Section | How |
-|---------|-----|
-| Control plane top consumers | VictoriaMetrics `apiserver_request_total` by `namespace` + Kubernetes MCP `ProjectControlPlane` join |
-| Edge top consumers | Skip with noted limitation until `AIGatewayRoute` resources exist or stat tags are propagated |
-| New projects this week | Kubernetes MCP `ProjectControlPlane` filtered by `creationTimestamp` |
-| Karmada per-project | Not available; use global binding count + new project count as proxy |
+| Project | Avg RPS | P90 latency | 4xx rate | 5xx rate |
+|---------|--------:|------------:|---------:|---------:|
+| `project-name` | N | N ms | N% | N% |
+
+Resolve `httproute_namespace` → project name via the `kube_namespace_labels` join. If the join
+yields an unfamiliar cluster name pattern, note it as unresolved rather than omitting the row.

--- a/plugins/datum-platform/skills/operational-review/consumer-identity.md
+++ b/plugins/datum-platform/skills/operational-review/consumer-identity.md
@@ -1,0 +1,157 @@
+# Consumer Identity Mapping
+
+This document covers how to get per-consumer breakdowns in operational reports and
+what work is needed to close the gaps.
+
+## Current State
+
+| Layer | Consumer identity available? | Source |
+|-------|------------------------------|--------|
+| Control plane (API server) | **Yes** | `apiserver_request_total{namespace=...}` + `ProjectControlPlane` |
+| Edge traffic (Envoy) | **No** | Envoy metrics carry only infra namespace labels |
+| Karmada provisioning | **Partial** | Binding count is global; no per-project breakdown |
+
+---
+
+## Control Plane: What Works Today
+
+Each Datum project gets a dedicated Kubernetes namespace. The namespace name is the
+project name and maps directly to `ProjectControlPlane.metadata.name`.
+
+### Step 1 — Query per-namespace API activity
+
+```
+topk(10, sum by (namespace) (rate(apiserver_request_total[5m])))
+```
+
+Filter system namespaces:
+```
+topk(10, sum by (namespace) (
+  rate(apiserver_request_total{
+    namespace!~"kube-.*|flux-system|cert-manager|.*-gateway.*|.*-system|monitoring"
+  }[5m])
+))
+```
+
+### Step 2 — Resolve namespace → owner via Kubernetes MCP
+
+```python
+get_kubernetes_resources(
+  apiVersion="infrastructure.miloapis.com/v1alpha1",
+  kind="ProjectControlPlane"
+)
+```
+
+Each resource yields:
+```yaml
+metadata:
+  name: <project-name>          # matches namespace in metrics
+  labels:
+    resourcemanager.miloapis.com/project-name: <project-name>
+  annotations:
+    resourcemanager.miloapis.com/owner-name: <org-name>
+```
+
+Join on `namespace == metadata.name` to build:
+
+| Owner | Project | Avg RPS | Error rate |
+|-------|---------|--------:|----------:|
+| org-abc | project-xyz | 1.2 | 0.3% |
+
+---
+
+## Edge Traffic: The Gap and How to Close It
+
+Envoy processes all inbound HTTPS requests but doesn't expose per-tenant metrics because
+JWT claims and project ID headers are not extracted as stat tags.
+
+### Option A — Envoy stat tag extraction (recommended)
+
+Configure the `EnvoyProxy` resource to extract a request header or JWT claim as a
+metric label. If every authenticated request carries an `x-project-id` header:
+
+```yaml
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: datum-gateway
+spec:
+  telemetry:
+    metrics:
+      sinks:
+        - type: OpenTelemetry
+          openTelemetry:
+            host: otel-collector.monitoring.svc
+            port: 4317
+  # Request header extraction for stat tags (requires Envoy stats_matcher or
+  # WASM extension — consult Envoy Gateway docs for the current supported approach)
+```
+
+Once a `project_id` label is propagated, the consumer query becomes:
+
+```
+topk(10, sum by (project_id) (rate(envoy_http_downstream_rq_total[5m])))
+```
+
+### Option B — AIGatewayRoute per-route metrics
+
+`aigateway.envoyproxy.io/AIGatewayRoute` CRDs are registered on the cluster but no
+resources are deployed yet. When routes are created per-consumer (one route per project
+or per AI service), Envoy will emit per-route stats that can be broken down by route name.
+
+The agent should check for `AIGatewayRoute` resources at review time:
+
+```python
+get_kubernetes_resources(
+  apiVersion="aigateway.envoyproxy.io/v1alpha1",
+  kind="AIGatewayRoute"
+)
+```
+
+If resources exist, use:
+```
+topk(10, sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_total[5m])))
+```
+
+and correlate `conn_manager_prefix` values with route names from the Kubernetes query.
+
+### Option C — Activity system (actor identity)
+
+The Activity system records every API operation with actor identity. If the Activity
+service is queryable (check for `activity.miloapis.com` resources or a dedicated
+VictoriaMetrics metric), it provides per-user/per-project request counts with full
+identity context — at higher query cost than Envoy metrics.
+
+---
+
+## Karmada: Per-Project Provisioning
+
+Karmada scheduler metrics (`karmada_scheduler_schedule_attempts_total`) are currently
+global — no project or namespace label is present.
+
+To get per-project provisioning counts, use the Kubernetes MCP to list
+`ProjectControlPlane` resources with their `creationTimestamp` and filter by the
+reporting period:
+
+```python
+get_kubernetes_resources(
+  apiVersion="infrastructure.miloapis.com/v1alpha1",
+  kind="ProjectControlPlane"
+)
+# Filter: creationTimestamp within report period
+# Group by: annotations["resourcemanager.miloapis.com/owner-name"]
+```
+
+This gives a count of new projects created per owner during the week, which is a
+reasonable proxy for provisioning activity until per-project Karmada metrics are available.
+
+---
+
+## Summary: What the Agent Should Do Each Week
+
+| Section | How |
+|---------|-----|
+| Control plane top consumers | VictoriaMetrics `apiserver_request_total` by `namespace` + Kubernetes MCP `ProjectControlPlane` join |
+| Edge top consumers | Skip with noted limitation until `AIGatewayRoute` resources exist or stat tags are propagated |
+| New projects this week | Kubernetes MCP `ProjectControlPlane` filtered by `creationTimestamp` |
+| Karmada per-project | Not available; use global binding count + new project count as proxy |

--- a/plugins/datum-platform/skills/operational-review/consumer-identity.md
+++ b/plugins/datum-platform/skills/operational-review/consumer-identity.md
@@ -152,6 +152,35 @@ get_kubernetes_resources(
 
 ---
 
+## Owner Email and User Profile Links
+
+The staff portal user profile URL is:
+
+```
+https://staff.datum.net/customers/users/{userId}
+```
+
+Where `{userId}` is the user's Kubernetes `metadata.name` — a numeric Zitadel user ID
+(e.g., `328747448287632651`).
+
+**What is available through current tooling:**
+- Project → owner org name: via `milo_projects_info{resource_name=...}.owner_name` or
+  `ProjectControlPlane.metadata.annotations["resourcemanager.miloapis.com/owner-name"]`
+- Org type (Personal vs Standard): via `milo_organizations_info`
+- Staff portal project link: `https://staff.datum.net/customers/projects/{project-name}`
+
+**What is NOT available through current tooling:**
+- User email address — stored in Zitadel, served via `iam.miloapis.com/v1alpha1` User
+  `spec.email`. Not in VictoriaMetrics metrics. The `milo_users_info` metric carries
+  only the numeric Zitadel ID as `resource_name`, with no email label.
+- Staff portal user profile link — requires mapping org name → user Zitadel ID → profile
+  URL. This mapping is not exposed via the Kubernetes MCP (User CRD returns no results
+  with current RBAC) or metrics.
+
+To add email + profile links to a report, direct IAM API access is required.
+
+---
+
 ## Report Table Format
 
 | Project | Avg RPS | P90 latency | 4xx rate | 5xx rate |

--- a/plugins/datum-platform/skills/operational-review/consumer-identity.md
+++ b/plugins/datum-platform/skills/operational-review/consumer-identity.md
@@ -99,6 +99,10 @@ topk(10, sum by (project_id) (rate(envoy_http_downstream_rq_total[5m])))
 resources are deployed yet. When routes are created per-consumer (one route per project
 or per AI service), Envoy will emit per-route stats that can be broken down by route name.
 
+The closest existing label is `envoy_http_conn_manager_prefix`. Confirmed current values:
+`http-80`, `https-443`, `aigateway-mcp-backend-listener-http`, `admin`, `eg-ready-http`,
+`eg-stats-http` — all infrastructure listeners, no per-consumer routes.
+
 The agent should check for `AIGatewayRoute` resources at review time:
 
 ```python
@@ -108,7 +112,7 @@ get_kubernetes_resources(
 )
 ```
 
-If resources exist, use:
+If resources exist, query:
 ```
 topk(10, sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_total[5m])))
 ```

--- a/plugins/datum-platform/skills/operational-review/queries.md
+++ b/plugins/datum-platform/skills/operational-review/queries.md
@@ -1,0 +1,93 @@
+# VictoriaMetrics Queries
+
+All queries target the prod VictoriaMetrics instance via the MCP server
+(`mcp__datum-infra-prod__victoria-metrics-mcp-server`).
+
+Use `start: YYYY-MM-DDT00:00:00Z` (7 days ago) and `end: YYYY-MM-DDT00:00:00Z` (today) unless
+otherwise noted.
+
+## RPS Queries
+
+### Global RPS — hourly (baseline/daily view)
+
+```
+sum(rate(envoy_http_downstream_rq_total[5m]))
+```
+
+- `step: 1h`
+- Use to compute daily averages and identify spike windows
+
+### Global RPS — 1m resolution max (true peak)
+
+```
+max_over_time(sum(rate(envoy_http_downstream_rq_total[1m]))[7d:1m])
+```
+
+- Single-point query at `start: today`, `step: 7d`
+- Returns the true 1m peak; hourly averaging hides intra-hour bursts
+
+### POP count (sanity check)
+
+```
+count(sum by (cluster) (rate(envoy_http_downstream_rq_total[5m])))
+```
+
+- `step: 1d` — confirm cluster count is stable throughout the week
+
+### Per-POP RPS — hourly
+
+```
+sum by (cluster) (rate(envoy_http_downstream_rq_total[5m]))
+```
+
+- `step: 1h`
+- Use to identify which cluster drives global spikes
+- Sort by descending average to rank POPs
+
+## Latency Queries
+
+Source histogram: `envoy_http_downstream_rq_time_bucket` (values in milliseconds).
+
+### Global P50 — hourly
+
+```
+histogram_quantile(0.50, sum(rate(envoy_http_downstream_rq_time_bucket[5m])) by (le))
+```
+
+### Global P90 — hourly
+
+```
+histogram_quantile(0.90, sum(rate(envoy_http_downstream_rq_time_bucket[5m])) by (le))
+```
+
+### Global P95 — hourly
+
+```
+histogram_quantile(0.95, sum(rate(envoy_http_downstream_rq_time_bucket[5m])) by (le))
+```
+
+All global latency queries: `step: 1h`
+
+### Per-POP P50/P90/P95 — 6h resolution
+
+Run all three in parallel, adding `by (le, cluster)`:
+
+```
+histogram_quantile(0.50, sum(rate(envoy_http_downstream_rq_time_bucket[5m])) by (le, cluster))
+histogram_quantile(0.90, sum(rate(envoy_http_downstream_rq_time_bucket[5m])) by (le, cluster))
+histogram_quantile(0.95, sum(rate(envoy_http_downstream_rq_time_bucket[5m])) by (le, cluster))
+```
+
+- `step: 6h` — reduces response size while preserving enough resolution to catch spikes
+- Use `statistics.median()` (not mean) when aggregating per-cluster — tail spike outliers
+  skew the mean and mask the true baseline
+
+## Anomaly Thresholds
+
+| Signal | Threshold | Action |
+|--------|-----------|--------|
+| Global RPS spike | > 150% of weekly avg | Note timestamp, correlate with per-POP and deployments |
+| Per-POP P90 spike | > 300ms | Flag in report, check if recurring |
+| Per-POP P95 spike | > 500ms | Flag in report |
+| Recurring P95 > 500ms | 3+ occurrences in week | Mark as "persistent issue, investigate" |
+| Latency regime shift | P90 changes by > 50ms mid-week and stays | Note possible traffic class change |

--- a/plugins/datum-platform/skills/operational-review/queries.md
+++ b/plugins/datum-platform/skills/operational-review/queries.md
@@ -92,32 +92,66 @@ histogram_quantile(0.95, sum(rate(envoy_http_downstream_rq_time_bucket[5m])) by 
 
 ## Edge Traffic: Top Consumers
 
-Consumer segmentation depends on available labels. Before running, confirm with:
+**Current state**: Envoy metrics carry no tenant/consumer identity. The `namespace` label on
+`envoy_http_downstream_rq_*` only reflects infrastructure namespaces (`datum-downstream-gateway`,
+`envoy-gateway-system`). Per-consumer edge breakdown is not available until one of the following
+is in place. See `consumer-identity.md` for the full options.
+
+### When `AIGatewayRoute` resources are deployed
+
+Each route will carry a name that maps to a consumer. Query:
 
 ```
-label_values(envoy_http_downstream_rq_total, namespace)
-label_values(envoy_http_downstream_rq_total, tenant)
+topk(10, sum by (route) (rate(envoy_http_downstream_rq_total[5m])))
 ```
 
-Use whichever label represents consumer identity (`tenant`, `namespace`, `source_cluster`, etc.).
+Until then, skip this section and note the limitation in the report.
 
-### Top consumers by RPS — weekly average
+---
 
-```
-topk(10, sum by (<consumer_label>) (rate(envoy_http_downstream_rq_total[5m])))
-```
+## Control Plane: Top Consumers (available today)
 
-- `step: 1d` — gives daily trend per consumer
-- Sort by descending average to rank top 10
+Each Datum project maps 1:1 to a Kubernetes namespace. `apiserver_request_total` carries a
+`namespace` label, so per-project control plane activity is available now.
 
-### Consumer share of total traffic
+### Top projects by API request volume — daily
 
 ```
-sum by (<consumer_label>) (rate(envoy_http_downstream_rq_total[5m]))
-  / ignoring(<consumer_label>) sum(rate(envoy_http_downstream_rq_total[5m]))
+topk(10, sum by (namespace) (rate(apiserver_request_total[5m])))
 ```
 
-- Reveals whether traffic is concentrated or distributed
+- `step: 1d`
+- Filter out system namespaces: add `namespace!~"kube-.*|flux-system|cert-manager|.*-system"`
+- Sort descending to rank top consumers
+
+### Top projects by error rate
+
+```
+topk(10, sum by (namespace) (rate(apiserver_request_total{code=~"4..|5.."}[5m])))
+  / ignoring(code) topk(10, sum by (namespace) (rate(apiserver_request_total[5m])))
+```
+
+- Surfaces projects generating the most rejected requests
+
+### Map namespace → project owner (Kubernetes MCP)
+
+`apiserver_request_total` gives namespace names, but not owner identity. Use the Kubernetes
+MCP to resolve the mapping:
+
+```
+get_kubernetes_resources(
+  apiVersion: "infrastructure.miloapis.com/v1alpha1",
+  kind: "ProjectControlPlane"
+)
+```
+
+Each `ProjectControlPlane` resource has:
+- `metadata.name` — matches the namespace name in `apiserver_request_total`
+- `metadata.labels["resourcemanager.miloapis.com/project-name"]` — human-readable project name
+- `metadata.annotations["resourcemanager.miloapis.com/owner-name"]` — organization/owner
+
+Join the metric results to this list by matching `namespace` → `metadata.name` to produce a
+table with columns: owner, project, avg RPS, error rate.
 
 ---
 

--- a/plugins/datum-platform/skills/operational-review/queries.md
+++ b/plugins/datum-platform/skills/operational-review/queries.md
@@ -6,7 +6,12 @@ All queries target the prod VictoriaMetrics instance via the MCP server
 Use `start: YYYY-MM-DDT00:00:00Z` (7 days ago) and `end: YYYY-MM-DDT00:00:00Z` (today) unless
 otherwise noted.
 
-## RPS Queries
+Before running queries for new metric categories (consumers, API groups, Karmada), use
+`metrics` or `label_values` to confirm available metric names and label cardinality.
+
+---
+
+## Edge Traffic: RPS
 
 ### Global RPS — hourly (baseline/daily view)
 
@@ -44,7 +49,9 @@ sum by (cluster) (rate(envoy_http_downstream_rq_total[5m]))
 - Use to identify which cluster drives global spikes
 - Sort by descending average to rank POPs
 
-## Latency Queries
+---
+
+## Edge Traffic: Latency
 
 Source histogram: `envoy_http_downstream_rq_time_bucket` (values in milliseconds).
 
@@ -78,9 +85,191 @@ histogram_quantile(0.90, sum(rate(envoy_http_downstream_rq_time_bucket[5m])) by 
 histogram_quantile(0.95, sum(rate(envoy_http_downstream_rq_time_bucket[5m])) by (le, cluster))
 ```
 
-- `step: 6h` — reduces response size while preserving enough resolution to catch spikes
-- Use `statistics.median()` (not mean) when aggregating per-cluster — tail spike outliers
-  skew the mean and mask the true baseline
+- `step: 6h`
+- Use `statistics.median()` (not mean) when aggregating per-cluster
+
+---
+
+## Edge Traffic: Top Consumers
+
+Consumer segmentation depends on available labels. Before running, confirm with:
+
+```
+label_values(envoy_http_downstream_rq_total, namespace)
+label_values(envoy_http_downstream_rq_total, tenant)
+```
+
+Use whichever label represents consumer identity (`tenant`, `namespace`, `source_cluster`, etc.).
+
+### Top consumers by RPS — weekly average
+
+```
+topk(10, sum by (<consumer_label>) (rate(envoy_http_downstream_rq_total[5m])))
+```
+
+- `step: 1d` — gives daily trend per consumer
+- Sort by descending average to rank top 10
+
+### Consumer share of total traffic
+
+```
+sum by (<consumer_label>) (rate(envoy_http_downstream_rq_total[5m]))
+  / ignoring(<consumer_label>) sum(rate(envoy_http_downstream_rq_total[5m]))
+```
+
+- Reveals whether traffic is concentrated or distributed
+
+---
+
+## Edge Traffic: Error Codes by API Group
+
+Envoy reports response codes via `envoy_http_downstream_rq_xx` counter metrics or
+through response code labels on the main histogram. Confirm available labels:
+
+```
+label_values(envoy_http_downstream_rq_total, response_code_class)
+label_values(envoy_http_downstream_rq_total, route)
+```
+
+### Error rate by response class — hourly
+
+```
+sum by (response_code_class) (rate(envoy_http_downstream_rq_total[5m]))
+```
+
+- `step: 1h`
+- Focus on `4xx` and `5xx` classes
+
+### Error rate by API group / route
+
+If a `route`, `virtual_host`, or `grpc_method` label maps to API groups:
+
+```
+sum by (route) (rate(envoy_http_downstream_rq_total{response_code_class="5xx"}[5m]))
+```
+
+- `step: 1h`
+- Sort by descending error rate; top offenders warrant investigation
+
+### 5xx error fraction
+
+```
+sum(rate(envoy_http_downstream_rq_total{response_code_class="5xx"}[5m]))
+  / sum(rate(envoy_http_downstream_rq_total[5m]))
+```
+
+- `step: 1h` — weekly trend of server-side error rate
+
+---
+
+## Control Plane: AI Edges Created
+
+AI edge creation events are tracked as Kubernetes resource lifecycle events.
+Confirm metric names:
+
+```
+metrics (search: "aiedge", "ai_edge", "datum_aiedge")
+```
+
+### AI edge creation rate — daily
+
+```
+sum(increase(aiedge_created_total[1d]))
+```
+
+- `step: 1d` — daily count of new AI edge resources created
+- Adjust metric name based on discovery above
+
+### Total AI edges active
+
+```
+sum(aiedge_active_total)
+```
+
+- Single-point query — current fleet size
+- Useful for week-over-week growth comparison
+
+---
+
+## Control Plane: Provisioning Performance (Karmada)
+
+Karmada propagation and scheduling metrics. Confirm names:
+
+```
+metrics (search: "karmada_scheduler", "karmada_binding", "karmada_work")
+```
+
+### Karmada scheduler queue latency P90 — hourly
+
+```
+histogram_quantile(0.90, sum(rate(karmada_scheduler_scheduling_duration_seconds_bucket[5m])) by (le))
+```
+
+- `step: 1h`
+- Measures time from resource binding to scheduler decision
+
+### Work propagation latency P90 — hourly (time-to-ready)
+
+```
+histogram_quantile(0.90, sum(rate(karmada_work_sync_duration_seconds_bucket[5m])) by (le))
+```
+
+- `step: 1h`
+- Measures time from work creation to application on member cluster
+
+### Per-cluster propagation latency P90
+
+```
+histogram_quantile(0.90, sum by (cluster) (rate(karmada_work_sync_duration_seconds_bucket[5m])) by (le, cluster))
+```
+
+- `step: 6h`
+- Use to identify slow member clusters
+
+### Binding failure rate
+
+```
+sum by (reason) (rate(karmada_scheduler_schedule_attempts_total{result="error"}[5m]))
+```
+
+- `step: 1h`
+- Surfaces scheduler errors by failure reason
+
+---
+
+## Control Plane: Error Codes by API Group
+
+Uses Kubernetes API server request metrics.
+
+### API server errors by resource group — hourly
+
+```
+sum by (group, code) (rate(apiserver_request_total{code=~"4..|5.."}[5m]))
+```
+
+- `step: 1h`
+- Groups errors by API group (`networking.datumapis.com`, `compute.datumapis.com`, etc.)
+  and HTTP response code
+
+### Error rate by verb and resource
+
+```
+sum by (resource, verb, code) (rate(apiserver_request_total{code=~"4..|5.."}[5m]))
+```
+
+- `step: 1h`
+- Useful for pinpointing which operations are failing
+
+### Webhook admission error rate
+
+```
+sum by (name, type) (rate(apiserver_admission_webhook_admission_duration_seconds_count{rejected="true"}[5m]))
+```
+
+- `step: 1h`
+- Surfaces admission webhook rejections by webhook name
+
+---
 
 ## Anomaly Thresholds
 
@@ -89,5 +278,10 @@ histogram_quantile(0.95, sum(rate(envoy_http_downstream_rq_time_bucket[5m])) by 
 | Global RPS spike | > 150% of weekly avg | Note timestamp, correlate with per-POP and deployments |
 | Per-POP P90 spike | > 300ms | Flag in report, check if recurring |
 | Per-POP P95 spike | > 500ms | Flag in report |
-| Recurring P95 > 500ms | 3+ occurrences in week | Mark as "persistent issue, investigate" |
-| Latency regime shift | P90 changes by > 50ms mid-week and stays | Note possible traffic class change |
+| Recurring P95 > 500ms | 3+ times in week | Mark as "persistent issue, investigate" |
+| Latency regime shift | P90 changes > 50ms mid-week and stays | Note possible traffic class change |
+| 5xx error rate | > 1% of total requests | Investigate by API group |
+| Karmada scheduling P90 | > 5s | Investigate scheduler queue depth |
+| Propagation P90 | > 60s | Investigate member cluster health |
+| Binding failure rate | Any sustained > 0 | Flag by failure reason |
+| API server 5xx | > 0.5% per group | Investigate by resource group |

--- a/plugins/datum-platform/skills/operational-review/queries.md
+++ b/plugins/datum-platform/skills/operational-review/queries.md
@@ -92,17 +92,19 @@ histogram_quantile(0.95, sum(rate(envoy_http_downstream_rq_time_bucket[5m])) by 
 
 ## Edge Traffic: Top Consumers
 
-**Current state**: Envoy metrics carry no tenant/consumer identity. The `namespace` label on
-`envoy_http_downstream_rq_*` only reflects infrastructure namespaces (`datum-downstream-gateway`,
-`envoy-gateway-system`). Per-consumer edge breakdown is not available until one of the following
-is in place. See `consumer-identity.md` for the full options.
+**Current state**: Envoy metrics carry no tenant/consumer identity. Confirmed labels on
+`envoy_http_downstream_rq_total` are: `cluster`, `container`, `endpoint`,
+`envoy_http_conn_manager_prefix`, `instance`, `job`, `namespace`, `node`, `pod`, `prometheus`.
+The `namespace` label only holds infra values (`datum-downstream-gateway`, `envoy-gateway-system`).
+There is no `tenant`, `project_id`, or equivalent label. Per-consumer edge breakdown is not
+available until one of the following is in place. See `consumer-identity.md` for the full options.
 
 ### When `AIGatewayRoute` resources are deployed
 
 Each route will carry a name that maps to a consumer. Query:
 
 ```
-topk(10, sum by (route) (rate(envoy_http_downstream_rq_total[5m])))
+topk(10, sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_total[5m])))
 ```
 
 Until then, skip this section and note the limitation in the report.

--- a/plugins/datum-platform/skills/operational-review/queries.md
+++ b/plugins/datum-platform/skills/operational-review/queries.md
@@ -92,68 +92,85 @@ histogram_quantile(0.95, sum(rate(envoy_http_downstream_rq_time_bucket[5m])) by 
 
 ## Edge Traffic: Top Consumers
 
-**Current state**: Envoy metrics carry no tenant/consumer identity. Confirmed labels on
-`envoy_http_downstream_rq_total` are: `cluster`, `container`, `endpoint`,
-`envoy_http_conn_manager_prefix`, `instance`, `job`, `namespace`, `node`, `pod`, `prometheus`.
-The `namespace` label only holds infra values (`datum-downstream-gateway`, `envoy-gateway-system`).
-There is no `tenant`, `project_id`, or equivalent label. Per-consumer edge breakdown is not
-available until one of the following is in place. See `consumer-identity.md` for the full options.
+**Do not use** `envoy_http_downstream_rq_total` for consumer analysis — it is the global
+listener metric and carries no consumer identity. Use `envoy_cluster_upstream_rq_total`,
+which carries `httproute_namespace=~"ns-.*"` — one namespace per project.
 
-### When `AIGatewayRoute` resources are deployed
+See `consumer-identity.md` for full background and the gateway-based alternative.
 
-Each route will carry a name that maps to a consumer. Query:
+### Top projects by upstream RPS
 
 ```
-topk(10, sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_total[5m])))
+topk(10,
+  label_replace(
+    sum by (httproute_namespace) (
+      rate(envoy_cluster_upstream_rq_total{httproute_namespace=~"ns-.*"}[5m])
+    ) * on (httproute_namespace) group_left(label_meta_datumapis_com_upstream_cluster_name)
+      kube_namespace_labels{label_meta_datumapis_com_upstream_cluster_name!=""},
+    "project_name", "$1",
+    "label_meta_datumapis_com_upstream_cluster_name", "cluster-_(.*)"
+  )
+)
 ```
 
-Until then, skip this section and note the limitation in the report.
-
----
-
-## Control Plane: Top Consumers (available today)
-
-Each Datum project maps 1:1 to a Kubernetes namespace. `apiserver_request_total` carries a
-`namespace` label, so per-project control plane activity is available now.
-
-### Top projects by API request volume — daily
-
-```
-topk(10, sum by (namespace) (rate(apiserver_request_total[5m])))
-```
-
-- `step: 1d`
-- Filter out system namespaces: add `namespace!~"kube-.*|flux-system|cert-manager|.*-system"`
-- Sort descending to rank top consumers
+- `step: 1d` for weekly trend
+- Result carries `project_name` label with the resolved project name
 
 ### Top projects by error rate
 
 ```
-topk(10, sum by (namespace) (rate(apiserver_request_total{code=~"4..|5.."}[5m])))
-  / ignoring(code) topk(10, sum by (namespace) (rate(apiserver_request_total[5m])))
-```
-
-- Surfaces projects generating the most rejected requests
-
-### Map namespace → project owner (Kubernetes MCP)
-
-`apiserver_request_total` gives namespace names, but not owner identity. Use the Kubernetes
-MCP to resolve the mapping:
-
-```
-get_kubernetes_resources(
-  apiVersion: "infrastructure.miloapis.com/v1alpha1",
-  kind: "ProjectControlPlane"
+label_replace(
+  sum by (httproute_namespace, envoy_response_code) (
+    rate(envoy_cluster_upstream_rq_xx{
+      httproute_namespace=~"ns-.*",
+      envoy_response_code=~"4..|5.."
+    }[5m])
+  ) * on (httproute_namespace) group_left(label_meta_datumapis_com_upstream_cluster_name)
+    kube_namespace_labels{label_meta_datumapis_com_upstream_cluster_name!=""},
+  "project_name", "$1",
+  "label_meta_datumapis_com_upstream_cluster_name", "cluster-_(.*)"
 )
 ```
 
-Each `ProjectControlPlane` resource has:
-- `metadata.name` — matches the namespace name in `apiserver_request_total`
-- `metadata.labels["resourcemanager.miloapis.com/project-name"]` — human-readable project name
-- `metadata.annotations["resourcemanager.miloapis.com/owner-name"]` — organization/owner
+### Per-project latency P90
 
-Join the metric results to this list by matching `namespace` → `metadata.name` to produce a
-table with columns: owner, project, avg RPS, error rate.
+```
+label_replace(
+  histogram_quantile(0.90,
+    sum by (httproute_namespace, le) (
+      rate(envoy_cluster_upstream_rq_time_bucket{httproute_namespace=~"ns-.*"}[5m])
+    ) * on (httproute_namespace) group_left(label_meta_datumapis_com_upstream_cluster_name)
+      kube_namespace_labels{label_meta_datumapis_com_upstream_cluster_name!=""}
+  ),
+  "project_name", "$1",
+  "label_meta_datumapis_com_upstream_cluster_name", "cluster-_(.*)"
+)
+```
+
+- `step: 6h`
+
+---
+
+## Control Plane: Top Consumers
+
+Same join pattern as edge traffic, using `apiserver_request_total`:
+
+### Top projects by API request volume
+
+```
+topk(10,
+  label_replace(
+    sum by (namespace) (
+      rate(apiserver_request_total{namespace=~"ns-.*"}[5m])
+    ) * on (namespace) group_left(label_meta_datumapis_com_upstream_cluster_name)
+      kube_namespace_labels{label_meta_datumapis_com_upstream_cluster_name!=""},
+    "project_name", "$1",
+    "label_meta_datumapis_com_upstream_cluster_name", "cluster-_(.*)"
+  )
+)
+```
+
+- `step: 1d`
 
 ---
 

--- a/plugins/datum-platform/skills/operational-review/queries.md
+++ b/plugins/datum-platform/skills/operational-review/queries.md
@@ -307,6 +307,90 @@ sum by (name, type) (rate(apiserver_admission_webhook_admission_duration_seconds
 
 ---
 
+## Control Plane: Project Count and Memory Pressure
+
+High project counts drive Kyverno informer cache growth, which causes memory pressure on
+the admission controller. Left undetected, this produces an OOMKill → webhook-down →
+stale UpdateRequest backlog loop (see datum-cloud/infra#2220). Track project count trend
+and admission controller headroom every review cycle.
+
+### Project count — current and weekly growth (Kubernetes MCP)
+
+```python
+get_kubernetes_resources(
+  apiVersion="infrastructure.miloapis.com/v1alpha1",
+  kind="ProjectControlPlane"
+)
+```
+
+- Count total resources for the current fleet size
+- Filter `creationTimestamp` within the report period to count new projects this week
+- Week-over-week growth = (this week count) − (last week count)
+
+### Project namespace count via metrics
+
+```
+count(kube_namespace_labels{label_resourcemanager_miloapis_com_project_name!=""})
+```
+
+- Single-point query — cross-check against Kubernetes MCP count
+- `step: 1d` for weekly trend; flag if growth rate is accelerating
+
+### Kyverno UpdateRequest backlog (Kubernetes MCP)
+
+```python
+get_kubernetes_resources(
+  apiVersion="kyverno.io/v2",
+  kind="UpdateRequest",
+  namespace="kyverno"
+)
+```
+
+- Count total UpdateRequests; anything above ~100 warrants attention
+- A large backlog (thousands) indicates the background controller is unable to drain —
+  a precursor to the admission webhook failure loop
+
+### Kyverno UpdateRequest backlog via metrics
+
+```
+kyverno_update_requests_total
+```
+
+- Confirm label set with `labels(kyverno_update_requests_total)`
+- `step: 1h` for weekly trend; look for sustained growth rather than transient spikes
+
+### Kyverno admission controller memory — usage vs limit
+
+```
+container_memory_working_set_bytes{
+  container="kyverno-admission-controller"
+}
+```
+
+```
+kube_pod_container_resource_limits{
+  resource="memory",
+  container="kyverno-admission-controller"
+}
+```
+
+- Compute utilization ratio: `working_set / limit`
+- `step: 1h` — flag if ratio exceeds 70% (leaves insufficient headroom before OOMKill)
+- Current limit after datum-cloud/infra#2220: 1536Mi
+
+### Kyverno admission controller restart rate
+
+```
+increase(kube_pod_container_status_restarts_total{
+  container="kyverno-admission-controller"
+}[1d])
+```
+
+- `step: 1d` — any restarts (exit code 137 = OOMKill) are a critical signal
+- Cross-check: `kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}`
+
+---
+
 ## Anomaly Thresholds
 
 | Signal | Threshold | Action |
@@ -321,3 +405,9 @@ sum by (name, type) (rate(apiserver_admission_webhook_admission_duration_seconds
 | Propagation P90 | > 60s | Investigate member cluster health |
 | Binding failure rate | Any sustained > 0 | Flag by failure reason |
 | API server 5xx | > 0.5% per group | Investigate by resource group |
+| Project count weekly growth | > 50 new projects/week | Note trend; assess memory headroom runway |
+| Kyverno UpdateRequest backlog | > 100 | Background controller is falling behind |
+| Kyverno UpdateRequest backlog | > 1,000 | Critical — webhook failure loop risk (see infra#2220) |
+| Kyverno admission memory utilization | > 70% of limit | Headroom warning; monitor for OOMKill |
+| Kyverno admission memory utilization | > 90% of limit | Imminent OOMKill risk; escalate |
+| Kyverno admission restarts | Any in week | Investigate for OOMKill (exit 137) |

--- a/plugins/datum-platform/skills/operational-review/report-format.md
+++ b/plugins/datum-platform/skills/operational-review/report-format.md
@@ -5,7 +5,7 @@
 | Attribute | Value |
 |-----------|-------|
 | Repo | `~/src/datum-cloud/engineering` |
-| Path | `reviews/ai-edge/YYYY-MM-DD-ai-edge-ops-review.md` |
+| Path | `reviews/ai-edge/YYYY-MM-DD-edge-ops-review.md` |
 | Branch | `ops/traffic-report-YYYY-MM-DD` |
 | PR title | `Ops Review: Weekly traffic report YYYY-MM-DD` |
 
@@ -199,7 +199,7 @@ Weekly operational report for {period}, sourced from VictoriaMetrics prod.
 
 ## Report
 
-`reviews/ai-edge/YYYY-MM-DD-ai-edge-ops-review.md`
+`reviews/ai-edge/YYYY-MM-DD-edge-ops-review.md`
 ```
 
 ## Git Workflow
@@ -210,7 +210,7 @@ git checkout main && git pull
 git checkout -b ops/traffic-report-YYYY-MM-DD
 mkdir -p reviews/ai-edge
 # Write report file
-git add reviews/ai-edge/YYYY-MM-DD-ai-edge-ops-review.md
+git add reviews/ai-edge/YYYY-MM-DD-edge-ops-review.md
 git commit -m "ops: add weekly traffic report for YYYY-MM-DD"
 git push -u origin ops/traffic-report-YYYY-MM-DD
 gh pr create --title "Ops Review: Weekly traffic report YYYY-MM-DD" --body "..."

--- a/plugins/datum-platform/skills/operational-review/report-format.md
+++ b/plugins/datum-platform/skills/operational-review/report-format.md
@@ -5,7 +5,7 @@
 | Attribute | Value |
 |-----------|-------|
 | Repo | `~/src/datum-cloud/engineering` |
-| Path | `reports/traffic/YYYY-MM-DD-datum-traffic.md` |
+| Path | `reviews/ai-edge/YYYY-MM-DD-ai-edge-ops-review.md` |
 | Branch | `ops/traffic-report-YYYY-MM-DD` |
 | PR title | `Ops Review: Weekly traffic report YYYY-MM-DD` |
 
@@ -199,7 +199,7 @@ Weekly operational report for {period}, sourced from VictoriaMetrics prod.
 
 ## Report
 
-`reports/traffic/YYYY-MM-DD-datum-traffic.md`
+`reviews/ai-edge/YYYY-MM-DD-ai-edge-ops-review.md`
 ```
 
 ## Git Workflow
@@ -208,9 +208,9 @@ Weekly operational report for {period}, sourced from VictoriaMetrics prod.
 # From ~/src/datum-cloud/engineering
 git checkout main && git pull
 git checkout -b ops/traffic-report-YYYY-MM-DD
-mkdir -p reports/traffic
+mkdir -p reviews/ai-edge
 # Write report file
-git add reports/traffic/YYYY-MM-DD-datum-traffic.md
+git add reviews/ai-edge/YYYY-MM-DD-ai-edge-ops-review.md
 git commit -m "ops: add weekly traffic report for YYYY-MM-DD"
 git push -u origin ops/traffic-report-YYYY-MM-DD
 gh pr create --title "Ops Review: Weekly traffic report YYYY-MM-DD" --body "..."

--- a/plugins/datum-platform/skills/operational-review/report-format.md
+++ b/plugins/datum-platform/skills/operational-review/report-format.md
@@ -35,6 +35,16 @@
 | AI edges created this week | N |
 | Overall 5xx error rate | N% |
 
+### Key Findings
+
+Promote findings here if they are action-required or incident-level. Leave out
+baseline/expected behavior. Use ⚠ for items needing investigation, ℹ for notable
+but non-urgent context.
+
+- ⚠ [Highest-priority finding — one line, with timestamp and magnitude]
+- ⚠ [Second priority finding]
+- ℹ [Notable but non-urgent observation]
+
 ---
 
 ## Edge Traffic
@@ -157,12 +167,18 @@ Source: `ProjectControlPlane` resources with `creationTimestamp` within the repo
 
 ## Observations
 
-- [Control plane traffic share]
+Background context and baseline notes. Do NOT duplicate Key Findings here —
+action-required items belong in the Summary. Reserve this section for:
+
+- Expected traffic distribution (control plane share, edge POP baselines)
+- POP burst leaders and regime changes
+- Spike correlation notes that don't rise to incident level
+- Anything that provides useful context for future reports
+
+- [Control plane traffic share — expected distribution]
 - [Edge POP burst leaders]
+- [Regime changes or gradual shifts]
 - [Spike correlation notes]
-- [Consumer concentration or growth trends]
-- [Persistent error patterns]
-- [Provisioning health summary]
 ```
 
 ## PR Body Template

--- a/plugins/datum-platform/skills/operational-review/report-format.md
+++ b/plugins/datum-platform/skills/operational-review/report-format.md
@@ -106,6 +106,28 @@ Sorted by P90. Spikes excluded from median; noted separately.
 
 ---
 
+## Project Count and Control Plane Health
+
+Added after datum-cloud/infra#2220: high project count drives Kyverno informer cache growth
+and admission controller memory pressure.
+
+| Metric | Value | vs last week |
+|--------|-------|-------------|
+| Total projects | N | +N |
+| New projects this week | N | — |
+| Kyverno UpdateRequest backlog | N | +N |
+| Kyverno admission memory utilization | N% of NMi limit | — |
+| Kyverno admission restarts this week | N | — |
+
+**Memory headroom runway** (at current growth rate): _N weeks until 90% utilization_
+
+Flag in Key Findings if:
+- UpdateRequest backlog > 1,000
+- Memory utilization > 70%
+- Any admission controller restarts occurred
+
+---
+
 ## Top Consumers
 
 ### Control Plane (available)

--- a/plugins/datum-platform/skills/operational-review/report-format.md
+++ b/plugins/datum-platform/skills/operational-review/report-format.md
@@ -85,15 +85,30 @@ Sorted by P90. Spikes excluded from median; noted separately.
 
 ## Top Consumers
 
-Top 10 tenants/namespaces by request volume over the review period.
+### Control Plane (available)
 
-| Consumer | Avg RPS | % of total | Notable pattern |
-|----------|--------:|-----------:|-----------------|
-| ... | ... | ...% | ... |
+Top 10 projects by API request volume. Source: `apiserver_request_total` by `namespace`,
+joined with `ProjectControlPlane` resources for owner resolution.
 
-**Observations:**
-- [Traffic concentration or distribution notes]
-- [Any consumer with unusual growth or decline]
+| Owner | Project | Avg RPS | Error rate | Notable pattern |
+|-------|---------|--------:|----------:|-----------------|
+| ... | ... | ... | ...% | ... |
+
+### Edge (not yet available)
+
+Per-consumer edge breakdown requires tenant identity to be propagated to Envoy metrics.
+See `consumer-identity.md` for the options. Until resolved, note:
+
+> Consumer-level edge segmentation is unavailable. Envoy metrics carry only infrastructure
+> namespace labels. See `consumer-identity.md` for remediation options.
+
+### New Projects This Week
+
+Source: `ProjectControlPlane` resources with `creationTimestamp` within the report period.
+
+| Owner | Project | Created |
+|-------|---------|---------|
+| ... | ... | ... |
 
 ---
 

--- a/plugins/datum-platform/skills/operational-review/report-format.md
+++ b/plugins/datum-platform/skills/operational-review/report-format.md
@@ -130,22 +130,24 @@ Flag in Key Findings if:
 
 ## Top Consumers
 
-### Control Plane (available)
+### Edge traffic
+
+Top 10 projects by upstream RPS. Source: `envoy_cluster_upstream_rq_total` by
+`httproute_namespace`, joined with `kube_namespace_labels` to resolve project name.
+See `consumer-identity.md` and `queries.md` for the full expressions.
+
+| Project | Avg RPS | P90 latency | 4xx rate | 5xx rate |
+|---------|--------:|------------:|---------:|---------:|
+| ... | ... | ... ms | ...% | ...% |
+
+### Control plane
 
 Top 10 projects by API request volume. Source: `apiserver_request_total` by `namespace`,
-joined with `ProjectControlPlane` resources for owner resolution.
+same join pattern.
 
-| Owner | Project | Avg RPS | Error rate | Notable pattern |
-|-------|---------|--------:|----------:|-----------------|
-| ... | ... | ... | ...% | ... |
-
-### Edge (not yet available)
-
-Per-consumer edge breakdown requires tenant identity to be propagated to Envoy metrics.
-See `consumer-identity.md` for the options. Until resolved, note:
-
-> Consumer-level edge segmentation is unavailable. Envoy metrics carry only infrastructure
-> namespace labels. See `consumer-identity.md` for remediation options.
+| Project | Avg API RPS | Error rate |
+|---------|------------:|-----------:|
+| ... | ... | ...% |
 
 ### New Projects This Week
 

--- a/plugins/datum-platform/skills/operational-review/report-format.md
+++ b/plugins/datum-platform/skills/operational-review/report-format.md
@@ -14,11 +14,11 @@
 ## Report Structure
 
 ```markdown
-# Datum Traffic Report — YYYY-MM-DD
+# Datum AI Edge — Ops Review YYYY-MM-DD
 
 **Period:** YYYY-MM-DD through YYYY-MM-DD
-**Source:** `envoy_http_downstream_rq_total`, `envoy_http_downstream_rq_time_bucket` via VictoriaMetrics (prod)
-**Scope:** Global Envoy edge ingress across all POPs
+**Source:** VictoriaMetrics (prod)
+**Scope:** Edge traffic, top consumers, error rates, control plane provisioning
 
 ---
 
@@ -27,29 +27,31 @@
 | Metric | Value |
 |--------|-------|
 | POPs reporting | N |
-| Weekly average | N RPS |
+| Weekly average RPS | N |
 | Baseline range | N–N RPS |
 | Peak (1m resolution) | **N RPS** |
+| Global P90 latency (weekly median) | N ms |
+| AI edges active | N |
+| AI edges created this week | N |
+| Overall 5xx error rate | N% |
 
 ---
 
-## Daily Averages
+## Edge Traffic
+
+### Daily Averages
 
 | Date | Avg RPS |
 |------|--------:|
 | ... | ... |
 
----
+### Notable Spikes (>150% of weekly avg)
 
-## Notable Spikes (>150 RPS)
+| Timestamp (UTC) | RPS | Correlated event |
+|-----------------|----:|-----------------|
+| ... | ... | ... |
 
-| Timestamp (UTC) | RPS |
-|-----------------|----:|
-| ... | ... |
-
----
-
-## Latency (ms)
+### Latency (ms)
 
 Global aggregate across all POPs.
 
@@ -58,11 +60,9 @@ Global aggregate across all POPs.
 | ... | ... | ... | ... | ... | ... | ... |
 | **Weekly** | **N** | **N** | **N** | **N** | **N** | **N** |
 
-**Note:** [Explain any notable pattern in the distribution, e.g. bimodal split.]
+**Note:** [Explain any notable distribution pattern, e.g. bimodal split.]
 
----
-
-## Latency by POP (weekly median, ms)
+### Latency by POP (weekly median, ms)
 
 Sorted by P90. Spikes excluded from median; noted separately.
 
@@ -73,15 +73,70 @@ Sorted by P90. Spikes excluded from median; noted separately.
 **Key findings:**
 - [Fastest POP]
 - [Slowest POP]
-- [Any incident-level anomalies]
+- [Incident-level anomalies]
 
----
-
-## Per-POP Breakdown
+### Per-POP Breakdown
 
 | Cluster | Avg RPS | Peak RPS |
 |---------|--------:|---------:|
 | ... | ... | ... |
+
+---
+
+## Top Consumers
+
+Top 10 tenants/namespaces by request volume over the review period.
+
+| Consumer | Avg RPS | % of total | Notable pattern |
+|----------|--------:|-----------:|-----------------|
+| ... | ... | ...% | ... |
+
+**Observations:**
+- [Traffic concentration or distribution notes]
+- [Any consumer with unusual growth or decline]
+
+---
+
+## Error Codes by API Group
+
+### Edge (Envoy)
+
+| API Group / Route | 4xx Rate | 5xx Rate | Notes |
+|-------------------|--------:|--------:|-------|
+| ... | ...% | ...% | ... |
+
+**Overall 5xx rate:** N% (threshold: 1%)
+
+### Control Plane (API Server)
+
+| API Group | Code | Rate | Notes |
+|-----------|------|-----:|-------|
+| ... | ... | ... | ... |
+
+**Webhook admission rejections:** [N rejections by webhook name, or "none"]
+
+---
+
+## Control Plane: AI Edge Provisioning
+
+| Metric | Value |
+|--------|-------|
+| AI edges active | N |
+| Created this week | N |
+| Scheduling P90 | N s |
+| Propagation P90 (time-to-ready) | N s |
+| Binding failures | N |
+
+### Provisioning Latency by Member Cluster
+
+| Cluster | Propagation P90 | Anomalies |
+|---------|----------------:|-----------|
+| ... | ... s | ... |
+
+**Key findings:**
+- [Fastest cluster]
+- [Slowest cluster]
+- [Any binding failures or scheduler errors]
 
 ---
 
@@ -90,21 +145,25 @@ Sorted by P90. Spikes excluded from median; noted separately.
 - [Control plane traffic share]
 - [Edge POP burst leaders]
 - [Spike correlation notes]
-- [Any persistent issues flagged]
+- [Consumer concentration or growth trends]
+- [Persistent error patterns]
+- [Provisioning health summary]
 ```
 
 ## PR Body Template
 
 ```markdown
-## Ops Review — Global Envoy Edge Ingress Traffic
+## Ops Review — Datum AI Edge
 
-Weekly traffic report for {period}, sourced from VictoriaMetrics prod.
+Weekly operational report for {period}, sourced from VictoriaMetrics prod.
 
 ## Summary
 
 - **{N} POPs** reporting
-- **{N} RPS** weekly average; baseline {N}–{N} RPS
-- **{N} RPS** peak (1m resolution, {timestamp})
+- **{N} RPS** weekly average; baseline {N}–{N} RPS; peak **{N} RPS** at {timestamp}
+- Global P90 latency: **{N} ms** weekly median
+- **{N} AI edges** active; **{N}** created this week
+- 5xx error rate: **{N}%** overall
 - {One-line notable finding}
 - {One-line notable finding}
 
@@ -129,10 +188,10 @@ gh pr create --title "Ops Review: Weekly traffic report YYYY-MM-DD" --body "..."
 
 ## Incremental Updates
 
-If asked to add data to an existing report (e.g. "add latencies"), amend the report in place:
+If asked to add data to an existing report (e.g. "add latencies", "add consumer breakdown"):
 
 1. Read the current file
-2. Add the new section in the appropriate position (Latency before Per-POP Breakdown)
-3. Update the `**Source:**` line to include the new metric
+2. Add the new section in the appropriate position (follow the structure order above)
+3. Update the `**Source:**` line to include the new metric if needed
 4. Commit with a short message: `ops: add {section} to traffic report`
 5. Push — the existing PR updates automatically

--- a/plugins/datum-platform/skills/operational-review/report-format.md
+++ b/plugins/datum-platform/skills/operational-review/report-format.md
@@ -165,20 +165,6 @@ Source: `ProjectControlPlane` resources with `creationTimestamp` within the repo
 
 ---
 
-## Observations
-
-Background context and baseline notes. Do NOT duplicate Key Findings here —
-action-required items belong in the Summary. Reserve this section for:
-
-- Expected traffic distribution (control plane share, edge POP baselines)
-- POP burst leaders and regime changes
-- Spike correlation notes that don't rise to incident level
-- Anything that provides useful context for future reports
-
-- [Control plane traffic share — expected distribution]
-- [Edge POP burst leaders]
-- [Regime changes or gradual shifts]
-- [Spike correlation notes]
 ```
 
 ## PR Body Template

--- a/plugins/datum-platform/skills/operational-review/report-format.md
+++ b/plugins/datum-platform/skills/operational-review/report-format.md
@@ -47,6 +47,19 @@ but non-urgent context.
 
 ---
 
+## Open Incidents
+
+Incidents from `datum-cloud/engineering` with label `:incident/issue` that are open or
+were opened/closed during the report period, filtered for AI Edge relevance.
+
+| # | Title | Status | Opened | Correlation |
+|---|-------|--------|--------|-------------|
+| [#N](link) | ... | OPEN / Closed YYYY-MM-DD | YYYY-MM-DD | [metric anomaly or "none"] |
+
+> If no relevant incidents: *No open incidents affecting AI Edge during this period.*
+
+---
+
 ## Edge Traffic
 
 ### Daily Averages

--- a/plugins/datum-platform/skills/operational-review/report-format.md
+++ b/plugins/datum-platform/skills/operational-review/report-format.md
@@ -1,0 +1,138 @@
+# Report Format and Publishing
+
+## File Convention
+
+| Attribute | Value |
+|-----------|-------|
+| Repo | `~/src/datum-cloud/engineering` |
+| Path | `reports/traffic/YYYY-MM-DD-datum-traffic.md` |
+| Branch | `ops/traffic-report-YYYY-MM-DD` |
+| PR title | `Ops Review: Weekly traffic report YYYY-MM-DD` |
+
+`YYYY-MM-DD` is today's date (end of the reporting period).
+
+## Report Structure
+
+```markdown
+# Datum Traffic Report — YYYY-MM-DD
+
+**Period:** YYYY-MM-DD through YYYY-MM-DD
+**Source:** `envoy_http_downstream_rq_total`, `envoy_http_downstream_rq_time_bucket` via VictoriaMetrics (prod)
+**Scope:** Global Envoy edge ingress across all POPs
+
+---
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| POPs reporting | N |
+| Weekly average | N RPS |
+| Baseline range | N–N RPS |
+| Peak (1m resolution) | **N RPS** |
+
+---
+
+## Daily Averages
+
+| Date | Avg RPS |
+|------|--------:|
+| ... | ... |
+
+---
+
+## Notable Spikes (>150 RPS)
+
+| Timestamp (UTC) | RPS |
+|-----------------|----:|
+| ... | ... |
+
+---
+
+## Latency (ms)
+
+Global aggregate across all POPs.
+
+| Date | P50 avg | P50 max | P90 avg | P90 max | P95 avg | P95 max |
+|------|--------:|--------:|--------:|--------:|--------:|--------:|
+| ... | ... | ... | ... | ... | ... | ... |
+| **Weekly** | **N** | **N** | **N** | **N** | **N** | **N** |
+
+**Note:** [Explain any notable pattern in the distribution, e.g. bimodal split.]
+
+---
+
+## Latency by POP (weekly median, ms)
+
+Sorted by P90. Spikes excluded from median; noted separately.
+
+| Cluster | P50 | P90 | P95 | Anomalies |
+|---------|----:|----:|----:|-----------|
+| ... | ... | ... | ... | ... |
+
+**Key findings:**
+- [Fastest POP]
+- [Slowest POP]
+- [Any incident-level anomalies]
+
+---
+
+## Per-POP Breakdown
+
+| Cluster | Avg RPS | Peak RPS |
+|---------|--------:|---------:|
+| ... | ... | ... |
+
+---
+
+## Observations
+
+- [Control plane traffic share]
+- [Edge POP burst leaders]
+- [Spike correlation notes]
+- [Any persistent issues flagged]
+```
+
+## PR Body Template
+
+```markdown
+## Ops Review — Global Envoy Edge Ingress Traffic
+
+Weekly traffic report for {period}, sourced from VictoriaMetrics prod.
+
+## Summary
+
+- **{N} POPs** reporting
+- **{N} RPS** weekly average; baseline {N}–{N} RPS
+- **{N} RPS** peak (1m resolution, {timestamp})
+- {One-line notable finding}
+- {One-line notable finding}
+
+## Report
+
+`reports/traffic/YYYY-MM-DD-datum-traffic.md`
+```
+
+## Git Workflow
+
+```bash
+# From ~/src/datum-cloud/engineering
+git checkout main && git pull
+git checkout -b ops/traffic-report-YYYY-MM-DD
+mkdir -p reports/traffic
+# Write report file
+git add reports/traffic/YYYY-MM-DD-datum-traffic.md
+git commit -m "ops: add weekly traffic report for YYYY-MM-DD"
+git push -u origin ops/traffic-report-YYYY-MM-DD
+gh pr create --title "Ops Review: Weekly traffic report YYYY-MM-DD" --body "..."
+```
+
+## Incremental Updates
+
+If asked to add data to an existing report (e.g. "add latencies"), amend the report in place:
+
+1. Read the current file
+2. Add the new section in the appropriate position (Latency before Per-POP Breakdown)
+3. Update the `**Source:**` line to include the new metric
+4. Commit with a short message: `ops: add {section} to traffic report`
+5. Push — the existing PR updates automatically


### PR DESCRIPTION
## Summary

- Adds a dedicated `operational-reviewer` agent that owns the full ops review workflow end-to-end
- Removes ops review from `sre.md` — SRE stays focused on infrastructure and deployment
- Broadens the `operational-review` skill scope from Envoy edge ingress to the full Datum AI Edge

## What changed

**`agents/operational-reviewer.md`** (new) — Standalone agent triggered by phrases like "ops review", "traffic report", "consumer breakdown", "provisioning report". Owns the query → analyze → anomaly detection → PR workflow. Documents scope, known patterns, and anomaly thresholds.

**`agents/sre.md`** — Removed `## Operational Reviews` section and `operational-review` skill reference.

**`skills/operational-review/SKILL.md`** — Reframed from "Envoy edge ingress" to "Datum AI Edge." Two named domains:
- **Edge Traffic**: requests processed, latency, top consumers by volume, error codes by API group
- **Control Plane**: AI edges created/active, Karmada provisioning latency, API server errors by resource group

**`skills/operational-review/queries.md`** — Expanded with five new query categories:
- Top consumers — `topk` by tenant/namespace label with label discovery step
- Edge error codes — Envoy `response_code_class` breakdown, 5xx fraction, per-route errors
- AI edges created/active — creation rate and fleet size
- Karmada provisioning — scheduler P90, propagation P90 per member cluster, binding failure rate
- API server errors — `apiserver_request_total` by group/code, webhook admission rejections
- New anomaly thresholds for 5xx rate, Karmada scheduling P90, propagation P90, binding failures

**`skills/operational-review/report-format.md`** — Updated report structure with new sections:
- Top Consumers table (avg RPS, % of total, notable pattern)
- Error Codes by API Group (edge + control plane subsections)
- Control Plane: AI Edge Provisioning (active count, created, scheduling/propagation P90, per-cluster table)
- PR summary template updated to include AI edge count and 5xx error rate

## Test plan

- [ ] `claude plugin validate .` passes
- [ ] Operational Reviewer agent can produce a complete weekly report end-to-end using only this skill as a guide