### PR TITLE
fix(operational-review): correct kyverno container label and memory limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Notable changes to the Datum Cloud Claude Code plugins.
 
+## [1.6.1] - 2026-04-27
+
+### Fixed
+
+- **Kyverno container label** (`operational-review`) — Corrected three queries that filtered on `container="kyverno-admission-controller"` (returns no data) to the actual cAdvisor/kube-state-metrics label `container="kyverno"`. Added `namespace="kyverno-system"` scoping to all three queries.
+- **Kyverno memory limit comment** (`operational-review`) — Updated stale `1536Mi` figure to the current confirmed limit of `2048Mi (2Gi)` across all 18 clusters.
+- **`kyverno_update_requests_total` availability** (`operational-review`) — Added note that this metric is not emitted by the deployed Kyverno version and that the Kubernetes MCP `UpdateRequest` path is the only viable approach.
+
 ## [1.6.0] - 2026-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A marketplace for Claude Code plugins providing platform engineering tools and a
 
 | Plugin | Description | Version |
 |--------|-------------|---------|
-| [datum-platform](./plugins/datum-platform/) | Kubernetes platform engineering automation with aggregated API servers, controller patterns, and GitOps deployment | 1.6.0 |
+| [datum-platform](./plugins/datum-platform/) | Kubernetes platform engineering automation with aggregated API servers, controller patterns, and GitOps deployment | 1.6.1 |
 | [datum-gtm](./plugins/datum-gtm/) | Go-to-market automation with commercial strategy, product discovery, and customer support | 1.0.0 |
 | [milo-activity](./plugins/milo-activity/) | Query audit logs, investigate incidents, and author ActivityPolicies using the Milo Activity service | 1.0.0 |
 

--- a/plugins/datum-platform/.claude-plugin/plugin.json
+++ b/plugins/datum-platform/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datum-platform",
   "description": "Kubernetes platform engineering automation with aggregated API servers, controller patterns, GitOps deployment, and platform capabilities",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "Datum Cloud",
     "url": "https://github.com/datum-cloud"

--- a/plugins/datum-platform/skills/operational-review/queries.md
+++ b/plugins/datum-platform/skills/operational-review/queries.md
@@ -369,6 +369,11 @@ get_kubernetes_resources(
 
 ### Kyverno UpdateRequest backlog via metrics
 
+**NOTE: `kyverno_update_requests_total` is not available in the current deployment** —
+this metric is not emitted by the Kyverno version running in prod (confirmed against live
+VictoriaMetrics). Use the Kubernetes MCP path above (`get_kubernetes_resources` for
+`UpdateRequest`) as the only viable approach for tracking backlog size.
+
 ```
 kyverno_update_requests_total
 ```
@@ -380,26 +385,29 @@ kyverno_update_requests_total
 
 ```
 container_memory_working_set_bytes{
-  container="kyverno-admission-controller"
+  namespace="kyverno-system",
+  container="kyverno"
 }
 ```
 
 ```
 kube_pod_container_resource_limits{
+  namespace="kyverno-system",
   resource="memory",
-  container="kyverno-admission-controller"
+  container="kyverno"
 }
 ```
 
 - Compute utilization ratio: `working_set / limit`
 - `step: 1h` — flag if ratio exceeds 70% (leaves insufficient headroom before OOMKill)
-- Current limit after datum-cloud/infra#2220: 1536Mi
+- Current limit confirmed across all 18 clusters: 2048Mi (2Gi)
 
 ### Kyverno admission controller restart rate
 
 ```
 increase(kube_pod_container_status_restarts_total{
-  container="kyverno-admission-controller"
+  namespace="kyverno-system",
+  container="kyverno"
 }[1d])
 ```
 


### PR DESCRIPTION
## Summary

Three fixes to `skills/operational-review/queries.md`, all diagnosed from live VictoriaMetrics prod data:

- **Container label mismatch (3 queries)**: Queries filtering `container="kyverno-admission-controller"` returned no data. The actual label value used by cAdvisor and kube-state-metrics is `container="kyverno"` (confirmed via `label_values`). All three affected queries (memory working set, memory limit, restart rate) are corrected to `container="kyverno"` and scoped with `namespace="kyverno-system"`.

- **Stale memory limit comment**: The comment referencing the post-infra#2220 memory limit said `1536Mi`. The actual current limit confirmed across all 18 clusters is **2048Mi (2Gi)**. Updated accordingly.

- **`kyverno_update_requests_total` unavailable**: This metric is not emitted by the Kyverno version running in prod (absent from VictoriaMetrics). A NOTE block is added to that query section directing operators to use the Kubernetes MCP `UpdateRequest` path (already documented above it) as the only viable approach.

Also bumps `datum-platform` plugin version `1.6.0 → 1.6.1` per release checklist.

## Test plan

- [ ] Verify `container_memory_working_set_bytes{namespace="kyverno-system", container="kyverno"}` returns data in prod VictoriaMetrics
- [ ] Verify `kube_pod_container_resource_limits{namespace="kyverno-system", resource="memory", container="kyverno"}` returns data and limit value matches 2048Mi
- [ ] Verify `increase(kube_pod_container_status_restarts_total{namespace="kyverno-system", container="kyverno"}[1d])` returns data
- [ ] Confirm `kyverno_update_requests_total` remains absent from VictoriaMetrics (NOTE block is accurate)

Generated with [Claude Code](https://claude.ai/claude-code)