### PR TITLE
fix(operational-review): comment on oncall issue when traffic report PR is opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes to the Datum Cloud Claude Code plugins.
 
+## [1.7.1] - 2026-05-11
+
+### Changed
+
+- **Operational review skill** (`operational-review`) — After opening the traffic report PR, now finds the current on-call issue in `datum-cloud/engineering` (open issue titled "on-call: week of …") and posts a comment linking the review.
+
 ## [1.7.0] - 2026-04-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A marketplace for Claude Code plugins providing platform engineering tools and a
 
 | Plugin | Description | Version |
 |--------|-------------|---------|
-| [datum-platform](./plugins/datum-platform/) | Kubernetes platform engineering automation with aggregated API servers, controller patterns, and GitOps deployment | 1.7.0 |
+| [datum-platform](./plugins/datum-platform/) | Kubernetes platform engineering automation with aggregated API servers, controller patterns, and GitOps deployment | 1.7.1 |
 | [datum-gtm](./plugins/datum-gtm/) | Go-to-market automation with commercial strategy, product discovery, and customer support | 1.0.0 |
 | [milo-activity](./plugins/milo-activity/) | Query audit logs, investigate incidents, and author ActivityPolicies using the Milo Activity service | 1.0.0 |
 

--- a/plugins/datum-platform/.claude-plugin/plugin.json
+++ b/plugins/datum-platform/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datum-platform",
   "description": "Kubernetes platform engineering automation with aggregated API servers, controller patterns, GitOps deployment, and platform capabilities",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": {
     "name": "Datum Cloud",
     "url": "https://github.com/datum-cloud"

--- a/plugins/datum-platform/skills/operational-review/report-format.md
+++ b/plugins/datum-platform/skills/operational-review/report-format.md
@@ -237,7 +237,19 @@ mkdir -p reviews/ai-edge
 git add reviews/ai-edge/YYYY-MM-DD-edge-ops-review.md
 git commit -m "ops: add weekly traffic report for YYYY-MM-DD"
 git push -u origin ops/traffic-report-YYYY-MM-DD
-gh pr create --title "Ops Review: Weekly traffic report YYYY-MM-DD" --body "..."
+PR_URL=$(gh pr create --title "Ops Review: Weekly traffic report YYYY-MM-DD" --body "..." | tail -1)
+
+# Find the current on-call issue and drop a comment linking the review
+ONCALL_ISSUE=$(gh issue list \
+  --repo datum-cloud/engineering \
+  --search "on-call: week of" \
+  --state open \
+  --json number,title \
+  --jq '.[0].number')
+
+gh issue comment "$ONCALL_ISSUE" \
+  --repo datum-cloud/engineering \
+  --body "Weekly traffic report open for review: $PR_URL"
 ```
 
 ## Incremental Updates


### PR DESCRIPTION
## Summary

- After opening the weekly traffic report PR, the ops review skill now finds the current on-call issue in `datum-cloud/engineering` (open issue titled `on-call: week of …`) and posts a comment linking the review.

## Changes

- `operational-review/report-format.md` — Extended Git Workflow to capture the PR URL and post a comment to the active on-call issue via `gh issue comment`
- `plugin.json` — bumped to 1.7.1
- `CHANGELOG.md` / `README.md` — version updated

Fixes https://github.com/datum-cloud/engineering/issues/274 (manually done for this week's report; skill handles it automatically going forward).