### PR TITLE
feat(datum-platform): add AGPL-3.0 compliance audit skill

### DIFF
--- a/plugins/datum-platform/skills/agpl-compliance/SKILL.md
+++ b/plugins/datum-platform/skills/agpl-compliance/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: agpl-compliance
+description: >
+  Scan a project repository for strict AGPL-3.0 license compliance across Go, Rust, and
+  JavaScript/React codebases. Use this skill whenever the user asks to check, audit, verify,
+  or enforce AGPL license compliance on a project, repo, or codebase. Triggers on phrases like
+  "check agpl compliance", "audit license headers", "is this project agpl compliant",
+  "scan for license headers", "check my license files", "agpl audit", or any request involving
+  ensuring a project is properly licensed under AGPL. Always use this skill — don't wing
+  AGPL compliance checks from general knowledge.
+---
+
+# AGPL Compliance Skill
+
+Perform a thorough, pragmatic AGPL-3.0 compliance audit on a project repository. Produce a
+pass/fail summary with a prioritized violation list and concrete fix suggestions for each issue.
+
+---
+
+## Language Resources
+
+Per-language skip rules, header placement, and correct header format are in:
+
+| Language | Resource |
+|----------|----------|
+| Go | `resources/go.md` |
+| Rust | `resources/rust.md` |
+| JavaScript / TypeScript / React | `resources/javascript.md` |
+
+**Before scanning source files**, read the resource file for each language present in the
+repo. To add support for a new language, add a `resources/<lang>.md` following the same
+structure as the existing files.
+
+---
+
+## Scope of Audit
+
+### Source Files
+
+Detect which languages are present by looking for `go.mod` (Go), `Cargo.toml` (Rust),
+`package.json` (JS/TS). Read the corresponding resource file(s) to determine which files
+are in scope and which to skip.
+
+**Universal skip rules (all languages):**
+- `vendor/`, `third_party/`, `testdata/` directories
+- Protobuf-generated files (see per-language resource for specific patterns)
+- Test fixtures that are pure data files with no logic
+- Mock or generated client stubs
+
+### Project-Level Files That MUST Exist
+
+| File | Requirement |
+|------|-------------|
+| `LICENSE` or `LICENSE.md` or `COPYING` | Must contain the full AGPL-3.0 license text |
+| `README.md` or `README` | Must reference AGPL-3.0 and include a short license section |
+
+### Optional But Recommended
+
+- `NOTICE` file — required if the project incorporates third-party code that mandates attribution
+
+---
+
+## Header Validation Rules (all languages)
+
+- Must appear at the very top of the file (before package/import/use declarations)
+  — see per-language resource for language-specific exceptions
+- Must contain "GNU Affero General Public License" — not just "AGPL" or "AGPLv3"
+- Must include the `<https://www.gnu.org/licenses/>` URL or equivalent
+- Copyright year and author are required — flag if missing or placeholder (`<YEAR>`, `<AUTHOR>`)
+- SPDX short-form (`// SPDX-License-Identifier: AGPL-3.0-or-later`) is acceptable
+  IF accompanied by a full `LICENSE` file in the repo root; otherwise Critical
+
+---
+
+## Audit Procedure
+
+### Step 1 — Locate the Repository Root
+
+If the user provides a path, use it. Otherwise look for: `go.mod`, `Cargo.toml`,
+`package.json`, `.git/`. Confirm the root before scanning.
+
+### Step 2 — Load Language Resources
+
+Check which languages are present and read the relevant files from `resources/`.
+
+### Step 3 — Scan Project-Level Files
+
+**LICENSE check:**
+- File exists?
+- Contains "GNU AFFERO GENERAL PUBLIC LICENSE" and "Version 3"?
+- Is it the full text (not just a badge or a link)?
+
+**README check:**
+- File exists?
+- Contains a license section (`## License`, `# License`, `### License`)?
+- Does it name AGPL-3.0 explicitly?
+- Does it link to the LICENSE file or `https://www.gnu.org/licenses/agpl-3.0.html`?
+
+### Step 4 — Enumerate Source Files
+
+Walk the directory tree. Apply skip rules from the language resource files. For each
+in-scope file, read the first 30 lines and classify:
+
+- ✅ **Compliant** — valid header present
+- ❌ **Missing header** — no license header at all
+- ⚠️ **Wrong license** — header present but not AGPL (MIT, Apache, proprietary, etc.)
+- ⚠️ **Incomplete header** — partial AGPL text, missing required elements
+- ⚠️ **Placeholder header** — `<YEAR>` or `<AUTHOR>` unfilled
+
+### Step 5 — Compile the Report
+
+```
+## AGPL-3.0 Compliance Report — <project name>
+**Status: PASS / FAIL**
+Scanned: <N> files | Compliant: <N> | Violations: <N>
+
+---
+
+### Project-Level Files
+| File     | Status   | Notes |
+|----------|----------|-------|
+| LICENSE  | ✅ / ❌  | ...   |
+| README.md| ✅ / ❌  | ...   |
+
+---
+
+### Violations
+
+#### Critical (blocks compliance)
+- <file path> — <issue>
+  **Fix:** <exact corrective action>
+
+#### Advisory (should fix)
+- <file path> — <issue>
+  **Fix:** <exact corrective action>
+
+---
+
+### Skipped Files
+<N> files skipped. List path patterns skipped.
+
+---
+
+### Suggested Header
+<correct header for the detected copyright holder and year, ready to copy-paste>
+```
+
+**Severity classification:**
+
+| Issue | Severity |
+|-------|----------|
+| Missing LICENSE file | Critical |
+| LICENSE is wrong version (GPL-2.0, MIT, etc.) | Critical |
+| Source file has wrong license header | Critical |
+| Source file missing header entirely | Critical |
+| README missing license section | Critical |
+| SPDX short-form without full LICENSE file | Critical |
+| Header has unfilled placeholders | Advisory |
+| README has license section but no link | Advisory |
+
+---
+
+## Tone and Output
+
+- State pass or fail up front.
+- Group violations by severity — critical first.
+- Give a one-line fix for every violation.
+- More than 20 missing headers? List the first 10, summarize the rest. Offer to print the full list.
+- Fully compliant? Say so clearly and move on.
+- No padding.

--- a/plugins/datum-platform/skills/agpl-compliance/resources/go.md
+++ b/plugins/datum-platform/skills/agpl-compliance/resources/go.md
@@ -1,0 +1,50 @@
+# Go — AGPL-3.0 Compliance Rules
+
+## File Extensions in Scope
+`.go`
+
+## Skip Rules
+- Files starting with `// Code generated` or `// DO NOT EDIT` in the first 3 lines
+- Protobuf-generated files: `*.pb.go`, `*_grpc.pb.go`
+- Files under `vendor/`
+
+## Header Placement
+Must appear at the very top of the file — before the `package` declaration.
+
+**Exception**: `//go:build` and `// +build` constraint lines may appear before the header.
+Place the header immediately after any build constraints.
+
+Example with build constraint:
+```go
+//go:build linux
+
+// Copyright (C) <YEAR> <AUTHOR/ORG>
+//
+// ...license text...
+
+package foo
+```
+
+## Correct Header
+```go
+// Copyright (C) <YEAR> <AUTHOR/ORG>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+```
+
+## Detection Markers
+To quickly scan whether a file has the correct header, check the first 30 lines for:
+- `GNU Affero General Public License`
+- `https://www.gnu.org/licenses/`
+- A `Copyright` line with a year and author

--- a/plugins/datum-platform/skills/agpl-compliance/resources/javascript.md
+++ b/plugins/datum-platform/skills/agpl-compliance/resources/javascript.md
@@ -1,0 +1,65 @@
+# JavaScript / TypeScript — AGPL-3.0 Compliance Rules
+
+## File Extensions in Scope
+`.js`, `.jsx`, `.ts`, `.tsx`
+
+## Skip Rules
+
+### Directories — always skip entirely
+- `node_modules/`
+- `dist/`, `build/`, `.next/`, `out/` — bundler output
+- `.cache/`
+
+### Auto-generated files — skip if first 3 lines contain
+- `// @generated`
+- `// This file is auto-generated`
+- `/* eslint-disable */` combined with a generation comment
+
+### Protobuf/gRPC generated files
+- `*_pb.js`, `*_pb.ts`, `*_pb.d.ts`
+- `*_grpc_web_pb.js`
+
+### Config files — skip by filename pattern
+- `vite.config.*`
+- `next.config.*`
+- `tailwind.config.*`
+- `postcss.config.*`
+- `jest.config.*`
+- `babel.config.*`
+- `eslint.config.*`, `.eslintrc.*`, `.eslintrc.js`, `.eslintrc.cjs`
+- `prettier.config.*`, `.prettierrc.*`
+- `webpack.config.*`
+- `rollup.config.*`
+- `tsconfig*.json` (not a source file)
+
+## Header Placement
+Must appear at the very top of the file.
+
+**Exception**: `'use strict';` or `"use strict";` may appear before the header if already
+present in the file — flag as advisory to move it after the header.
+
+For `.tsx`/`.jsx` files, the header goes before any `import` statements.
+
+## Correct Header
+```js
+// Copyright (C) <YEAR> <AUTHOR/ORG>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+```
+
+## Detection Markers
+To quickly scan whether a file has the correct header, check the first 30 lines for:
+- `GNU Affero General Public License`
+- `https://www.gnu.org/licenses/`
+- A `Copyright` line with a year and author

--- a/plugins/datum-platform/skills/agpl-compliance/resources/rust.md
+++ b/plugins/datum-platform/skills/agpl-compliance/resources/rust.md
@@ -1,0 +1,42 @@
+# Rust — AGPL-3.0 Compliance Rules
+
+## File Extensions in Scope
+`.rs`
+
+## Skip Rules
+- Files under `target/`
+- `build.rs` if it contains only auto-generated scaffold (no substantive logic)
+- Protobuf-generated files: `*.pb.rs`, files under `src/gen/` or `src/generated/`
+- Files under `vendor/` or `third_party/`
+
+## Header Placement
+Must appear at the very top of the file — before any `use`, `mod`, `extern crate`, or
+attribute declarations (`#![...]`).
+
+**Exception**: Inner crate-level attributes (`#![allow(...)]`, `#![cfg_attr(...)]`) may
+appear before the header if the project convention requires it, but this should be flagged
+as advisory — the preferred order is header first.
+
+## Correct Header
+```rust
+// Copyright (C) <YEAR> <AUTHOR/ORG>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+```
+
+## Detection Markers
+To quickly scan whether a file has the correct header, check the first 30 lines for:
+- `GNU Affero General Public License`
+- `https://www.gnu.org/licenses/`
+- A `Copyright` line with a year and author


### PR DESCRIPTION
## Summary

- Adds a new `agpl-compliance` skill to the `datum-platform` plugin
- Audits Go, Rust, and JavaScript/TypeScript codebases for AGPL-3.0 license compliance
- Covers project-level `LICENSE`/`README` checks and per-file header validation with language-specific skip rules
- Produces a prioritized pass/fail report with actionable fix suggestions for every violation

## Test plan

- [ ] Load the skill in a Go project with missing license headers and confirm violations are reported correctly
- [ ] Load the skill in a project with a full AGPL-3.0 `LICENSE` file and compliant headers and confirm PASS result
- [ ] Verify skip rules exclude `vendor/`, generated, and testdata files from the scan
- [ ] Confirm SPDX short-form is flagged as Critical when no full `LICENSE` file is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)