### PR TITLE
Add changelog-entry skill: community-ready changelog posts for Datum's GitHub Discussions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes to the Datum Cloud Claude Code plugins.
 
+## [1.1.0] - 2026-07-08
+
+### Added
+
+- **Changelog entry skill** (`changelog-entry`, datum-gtm) — Guides the gtm-comms agent through turning raw engineering notes, PR/issue links, or a feature description into a ready-to-post entry for Datum's GitHub Discussions Changelog. Covers benefit-led titling, a fixed post structure (lead → hero feature → New/Improved/Fixed → docs links → single CTA), a voice pass that strips Kubernetes jargon and internal implementation detail, mandatory visual placeholders, community credit, and a scope gate that keeps marketing news and sub-100-word stubs out. Ships a fill-in `template.md`, a worked `example.md`, and a self-review checklist. Complements the Keep-a-Changelog release-file template in `gtm-templates`.
+
 ## [1.8.0] - 2026-05-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Notable changes to the Datum Cloud Claude Code plugins.
 
 ### Added
 
-- **Changelog entry skill** (`changelog-entry`, datum-gtm) — Guides the gtm-comms agent through turning raw engineering notes, PR/issue links, or a feature description into a ready-to-post entry for Datum's GitHub Discussions Changelog. Covers benefit-led titling, a fixed post structure (lead → hero feature → New/Improved/Fixed → docs links → single CTA), a voice pass that strips Kubernetes jargon and internal implementation detail, mandatory visual placeholders, community credit, and a scope gate that keeps marketing news and sub-100-word stubs out. Ships a fill-in `template.md`, a worked `example.md`, and a self-review checklist. Complements the Keep-a-Changelog release-file template in `gtm-templates`.
+- **Changelog entry skill** (`changelog-entry`, datum-gtm) — Guides the gtm-comms agent through turning raw engineering notes, PR/issue links, or a feature description into a hand-off-ready draft for Datum's GitHub Discussions Changelog. Covers benefit-led titling, a fixed post structure (lead → hero feature → New/Improved/Fixed, plus a breaking-changes heads-up and security wording → docs links → single CTA), a voice pass that strips Kubernetes jargon and internal implementation detail, an anti-fabrication rule with a `[VERIFY]` convention, a public-vs-private community credit gate, a scope gate with a stakeholder-override path, and a required pre-publish handoff block. Ships a fill-in `template.md`, a worked `example.md`, and a self-review checklist that mirrors every rule. Complements the Keep-a-Changelog release-file template in `gtm-templates`.
 
 ## [1.8.0] - 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A marketplace for Claude Code plugins providing platform engineering tools and a
 | Plugin | Description | Version |
 |--------|-------------|---------|
 | [datum-platform](./plugins/datum-platform/) | Kubernetes platform engineering automation with aggregated API servers, controller patterns, and GitOps deployment | 1.8.0 |
-| [datum-gtm](./plugins/datum-gtm/) | Go-to-market automation with commercial strategy, product discovery, and customer support | 1.0.0 |
+| [datum-gtm](./plugins/datum-gtm/) | Go-to-market automation with commercial strategy, product discovery, and customer support | 1.1.0 |
 | [milo-activity](./plugins/milo-activity/) | Query audit logs, investigate incidents, and author ActivityPolicies using the Milo Activity service | 1.0.0 |
 
 ## Installation
@@ -137,7 +137,7 @@ Go-to-market automation with commercial strategy, product discovery, and custome
 
 **Features:**
 - 4 specialized agents (product-discovery, commercial-strategist, gtm-comms, support-triage)
-- 3 skill modules for GTM workflows
+- 4 skill modules for GTM workflows
 - Commercial strategy and pricing analysis
 - Customer support triage automation
 

--- a/plugins/datum-gtm/.claude-plugin/plugin.json
+++ b/plugins/datum-gtm/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datum-gtm",
   "description": "Go-to-market automation with commercial strategy, product discovery, and customer support tools for Datum Cloud",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Datum Cloud",
     "url": "https://github.com/datum-cloud"

--- a/plugins/datum-gtm/agents/gtm-comms.md
+++ b/plugins/datum-gtm/agents/gtm-comms.md
@@ -86,13 +86,16 @@ Under 200 words. Structure:
 - One clear CTA
 
 ### Changelog Entry
-Factual, scannable. Categories:
-- **Added**: New features
-- **Changed**: Changes to existing functionality
-- **Fixed**: Bug fixes
-- **Deprecated**: Soon-to-be removed features
-- **Removed**: Removed features
-- **Security**: Security fixes
+Two distinct artifacts — pick by destination:
+
+- **Community changelog post** (the GitHub Discussions Changelog category) — a
+  benefit-led, user-facing announcement with a visual, docs links, and community
+  credit. Use the **`changelog-entry`** skill; it handles titling, the fixed
+  post structure, the jargon-stripping voice pass, and a pre-publish handoff
+  block.
+- **Keep-a-Changelog release file** (`CHANGELOG.md` in a repo) — factual and
+  scannable, grouped under Added / Changed / Fixed / Deprecated / Removed /
+  Security. Use the `gtm-templates` changelog format.
 
 ### Internal Enablement Brief
 Comprehensive internal document:
@@ -148,6 +151,7 @@ Before finalizing any content:
 
 ## Skills to Reference
 
-- `gtm-templates` — Blog, social, email, changelog, enablement templates
+- `changelog-entry` — Community-facing changelog post for the GitHub Discussions Changelog
+- `gtm-templates` — Blog, social, email, changelog-file, enablement templates
 - `platform-knowledge` — Services catalog for positioning
 - `pipeline-conductor` — Stage handoffs

--- a/plugins/datum-gtm/skills/changelog-entry/SKILL.md
+++ b/plugins/datum-gtm/skills/changelog-entry/SKILL.md
@@ -1,34 +1,53 @@
 ---
 name: changelog-entry
 description: >
-  Write a changelog entry for Datum Cloud's GitHub Discussions Changelog
-  category that meets Datum's content standards. Turns raw engineering notes,
-  PR/issue links, commit messages, or a one-line feature description into a
-  ready-to-post discussion title and markdown body. Use when someone says
-  "write a changelog entry", "announce this in the changelog", or "post this to
-  the changelog discussions" — this is the community-facing changelog POST, not
-  the Keep a Changelog release file (that lives in `gtm-templates`).
+  Turn raw engineering notes, PR/issue links, commit messages, or a one-line
+  feature description into a changelog entry for Datum Cloud's GitHub Discussions
+  Changelog category: a benefit-led title plus a markdown body, drafted for
+  users and ready to hand off for final capture and publish. Use when someone
+  says "write a changelog entry", "announce this in the changelog", or "post
+  this to the changelog discussions" — this is the community-facing changelog
+  POST, not the Keep a Changelog release file (that lives in `gtm-templates`).
 ---
 
 # Changelog Entry
 
-Produce a ready-to-post entry for the [Datum Cloud Changelog discussions](https://github.com/orgs/datum-cloud/discussions/categories/changelog):
-a benefit-led **title** plus a markdown **body**. The reader is a Datum *user*
-deciding whether this changes what they can do today — not an engineer reviewing
-the implementation.
+Produce an entry for the [Datum Cloud Changelog discussions](https://github.com/orgs/datum-cloud/discussions/categories/changelog):
+a benefit-led **title** plus a markdown **body**, written for a Datum *user*
+deciding whether this changes what they can do today — not for an engineer
+reviewing the implementation. The output is a **complete draft ready to hand
+off**, not a post you publish directly: it ends with a handoff block (Step 8)
+listing what a human must do first.
 
-**This is a different artifact from `gtm-templates`.** `gtm-templates` covers the
+This is a different artifact from `gtm-templates`, which covers the
 Keep-a-Changelog *release file* (`### Added / Changed / Fixed` in a repo's
-`CHANGELOG.md`). This skill produces a *community discussion post*: narrative,
-visual, and written for users. Don't paste a Keep-a-Changelog block into a
-discussion — reshape it with this skill.
-
-Model to imitate: **[datumctl v0.16.0 — Bring your own plugin catalog](https://github.com/datum-cloud/datum/discussions/259)**
-(context-then-benefit lead, `###` sections, fenced code, `> [!NOTE]` callouts,
-per-section 📖 docs links, compare-link footer).
+`CHANGELOG.md`). Don't paste a Keep-a-Changelog block into a discussion —
+reshape it with this skill.
 
 Use `template.md` for the fill-in skeleton and `example.md` for a full worked
-run (raw notes → finished post).
+run (raw notes → finished draft, including the handoff block).
+
+**Model to imitate:** [datumctl v0.16.0 — Bring your own plugin catalog](https://github.com/datum-cloud/datum/discussions/259)
+for *structure and voice* — context-then-benefit lead, `###` sections, fenced
+code, `> [!NOTE]` callouts, per-section 📖 docs links, compare-link footer. It
+predates the now-required visual, closing question, reaction invite, and
+community credit, so it is **not** a complete model for those — `example.md` is.
+(It links a PR in each header; PR links are fine for traceability, see Step 4.)
+
+## Ground rule: draft from the input, never fabricate
+
+The most common failure of this skill is inventing a specific to fill a slot.
+**Never invent** a scenario, docs URL, command syntax, flag, version, metric,
+product limit (retention window, quota, deprecation), or requester. If the input
+doesn't give you one:
+
+- **ask** the requester for it, or
+- mark it inline as **`[VERIFY: what to confirm]`** and carry it into the
+  Step 8 handoff block — never present an inferred specific as fact.
+
+For CLI features, verify command syntax against `--help` or docs rather than
+guessing flags or argument shapes. This mirrors the gtm-comms agent's hard rule:
+never fabricate capabilities or performance claims.
 
 ---
 
@@ -36,41 +55,58 @@ run (raw notes → finished post).
 
 ### Step 1 — Gather inputs
 
-From the notes/PRs/commits, pull out (and ask the requester only for what's
-genuinely missing):
+From the notes/PRs/commits, pull out (and ask only for what's genuinely
+missing rather than filling it in yourself — see the Ground rule):
 
 - **What a user can now do** — the capability, in plain terms.
-- **Who benefits and the concrete "so what"** — a real scenario, e.g. "useful
+- **The concrete "so what"** — the real scenario this helps with. It must come
+  from the input. If the input gives none, don't invent one: ask, or mark it
+  `[VERIFY]` and note it in the handoff block. (Shape it looks like: "useful
   when your upstream routes traffic by hostname — multi-tenant SaaS,
-  virtual-hosted buckets, model gateways that key off the request host."
-- **The docs page** that covers it (a `datum.net/docs/...` deep link).
-- **Community to credit** — anyone who requested or reported this, and the
-  Feature Request / bug discussion it resolves.
-- **Media** — is there a screenshot, GIF, or terminal recording? If not, you'll
-  emit a placeholder (Step 6).
-- **For a CLI release** — the version and the previous version (for the
-  compare-link footer).
+  virtual-hosted buckets, model gateways that key off the request host" — but
+  those specifics have to be *true of this feature*, not borrowed.)
+- **The docs page** — a `datum.net/docs/...` link **only if it is published and
+  live**. A draft/PR-only page is not a URL yet (Step 7).
+- **Who to credit, and whether it's safe to name them publicly** — the public
+  discussion where a user requested or reported it, *and* whether the requester
+  is a community member in a public thread vs. a design partner / NDA / internal
+  user (Step 7 credit gate).
+- **Media** — a screenshot, GIF, or terminal recording? If not, you'll emit a
+  placeholder (Step 6).
+- **For a CLI release** — the version, the previous version (compare footer),
+  and the real command syntax.
+- **Product limits** (retention, quotas, deprecation dates) only if the input
+  states them. Never assert a limit the input didn't give.
 
 ### Step 2 — Classify the entry (and gate on scope)
 
 | Type | Signal | Shape |
 |------|--------|-------|
-| **CLI release** | `datumctl vX.Y.Z`, a tag, release notes | Title pairs version + headline feature; body has hero feature + grouped changes + **compare-link footer** |
+| **CLI release** | `datumctl vX.Y.Z`, a tag, release notes | Title pairs version + headline feature; hero feature + grouped changes + **compare-link footer** |
 | **Feature launch** | one substantial user-facing capability | Benefit title; hero feature section with visual; docs link |
-| **Digest / roundup** | several small changes, none a headline on its own | Benefit title (not a grab-bag); changes grouped under New / Improved / Fixed |
+| **Digest / roundup** | several small changes, none a headline on its own | Benefit title (not a grab-bag); **no hero** — go straight to grouped changes |
 
 **Scope gate — stop before drafting if:**
 
 - **Not a product change.** Company/marketing news (handbook, website nav,
   design-system, hiring) does **not** belong in the changelog. Redirect to a
   blog post (`gtm-templates`) or drop it.
+- **Cosmetic UI change with no capability change** (a footer redesign, a color
+  tweak) — not a changelog entry on its own.
 - **Too thin to stand alone.** A stub under ~100 words of real substance should
-  be **held and merged into the next digest**, not posted by itself. Say so
-  instead of padding it.
+  be **held and merged into the next digest**, not posted by itself.
+
+**The gate holds regardless of who asks.** If someone — including marketing or a
+stakeholder — explicitly asked to include out-of-scope content, do **not**
+silently drop it and do **not** silently include it. Exclude it from the post,
+then name it in the Step 8 handoff block with the right venue (blog, separate
+post) so the requester can decide.
 
 ### Step 3 — Write the title
 
 Benefit-led **and** feature-named. Sentence case. `datumctl` always lowercase.
+The claim must match the feature — don't say "one command" for a three-command
+group.
 
 | Do | Don't |
 |----|-------|
@@ -78,7 +114,7 @@ Benefit-led **and** feature-named. Sentence case. `datumctl` always lowercase.
 | `datumctl v0.16.0 — Bring your own plugin catalog` | `datumctl v0.16.0` (version only) |
 | `Rewrite the Host header per route` | `AI Edge, Connectors, and Improvements` (vague grab-bag) |
 
-Name the feature, lead with the payoff. Avoid opening every title with
+Lead with the payoff, name the feature. Avoid opening every title with
 "Introducing X" — vary it. For a CLI release, pair the version with the headline
 feature using an em-dash (`—`).
 
@@ -88,38 +124,74 @@ Follow `template.md`:
 
 1. **Lead paragraph** — what you can now do + why it matters, 1–2 sentences, in
    "you can now…" voice. No preamble, no "we're excited to announce."
-2. **Hero feature** — the headline change, with the visual (Step 6) and a
+2. **Hero feature** — the headline change, with the visual (Step 6) and its
    concrete scenario. Use `###` headings and fenced code for commands/config.
+   *A pure digest has no single hero — omit this and go straight to the groups.*
 3. **Remaining changes** — grouped under `### New`, `### Improved`, `### Fixed`
-   (omit any group that's empty). One line each, benefit-first.
-4. **Docs deep-links** — a 📖 link per feature to `datum.net/docs/...`.
-5. **Closing** — community credit + a single pointed question (Step 7).
-6. **Footer (CLI releases)** — `**Full changelog:** [vA...vB](compare-url)`.
+   (omit empty groups; one benefit-first line each). The hero is **not** repeated
+   under `### New`. Don't restate the lead's scenario verbatim in a group.
+4. **Breaking changes / deprecations** — if any, a `### Heads-up` group rendered
+   with `> [!IMPORTANT]`, stating the **migration path** and any **deadline**.
+   Never bury a breaking change inside `### Fixed`.
+5. **Security fixes** — say what was fixed and who should act; do **not** publish
+   exploit detail. Link the advisory and credit the reporter only if the
+   disclosure is already public.
+6. **Docs deep-links** — one 📖 link per **major/new** feature to a live
+   `datum.net/docs/...` page (Step 7). `Improved` and `Fixed` lines don't need
+   their own docs link.
+7. **Closing** — community credit + a single pointed question (Step 7).
+8. **Footer (CLI releases)** — `**Full changelog:** [vA...vB](compare-url)`.
 
-Use `> [!NOTE]` / `> [!IMPORTANT]` callouts for upgrade or compatibility notes,
-as in the gold-standard post.
+**Code blocks must use real syntax.** In a CLI post the fenced block is what
+users copy — don't invent flags or argument shapes. Verify against `--help`/docs;
+if the syntax is unknown, ask or omit the block and flag it in Step 8.
+
+**Callouts only when earned.** Use `> [!NOTE]` / `> [!IMPORTANT]` for genuine
+upgrade or compatibility notes. If there's no real note, omit the callout — don't
+manufacture one to match the gold-standard's look.
+
+**Links.** Link live product docs, a CLI compare link, and — for traceability —
+the PR(s) that delivered a change if useful. **Never** link internal
+work-tracking issues (`enhancements/issues/NNN`) and never end with a bare "View
+the details on GitHub" pointing at one — the single most common mistake in past
+posts.
 
 ### Step 5 — Voice pass: translate engineer-speak to user outcomes
 
 Rewrite anything that describes *how it was built* into *what the user gets*.
-Cut internal implementation trivia entirely (e.g. "Replaced the Express BFF with
-Hono, 93% smaller" — a user does not care). Gloss or remove Kubernetes jargon:
+Cut internal implementation trivia entirely. The distinction that matters:
+
+- **Internal component/mechanism changed** → cut it. ("Replaced the Express BFF
+  with Hono"; "moved to cursor-based pagination"; "reconciled by the controller".)
+- **Observable effect on what the user installs or experiences** → keep it,
+  user-framed, mechanism dropped. (Smaller download, faster startup, lower
+  memory, quicker page loads.)
 
 | Engineer wrote | User reads |
 |----------------|------------|
 | "Added the `AccessLogConfig` CRD, reconciled by the logging-controller" | "Turn on access logs for any proxy" |
 | "reconciliation loop now converges faster" | "changes take effect in seconds" |
 | "logs stream from Envoy via the activity pipeline" | "your live traffic shows up in the dashboard" |
-| "exposed a new field on the spec" | "a new setting lets you…" |
+| "migrated to a shared transport, binary ~8% smaller" | "the CLI download is about 8% smaller" |
+| "p95 query latency down ~70% on large orgs" | "the slowest page loads are about 70% faster" |
+| "fixed a token-refresh race condition" | "fixed a bug that could briefly log you out" |
 
-If a term (CRD, controller, reconcile, webhook, informer) survives into the
-draft, it's a bug — replace it with the outcome.
+The list is illustrative — the test is whether the term describes *how it's
+built*. If a build-side term (CRD, controller, reconcile, webhook, informer,
+pagination, transport) survives into the draft, replace it with the outcome.
+Literal file/config paths (`~/.config/datumctl/config.yaml`) are plumbing — fold
+the effect into prose and drop the path unless the user must type it.
 
-### Step 6 — Visuals (every post needs at least one)
+> This is a user-facing artifact, so the general "Kubernetes-native — use
+> ecosystem terminology" voice guidance from `gtm-comms` and `gtm-templates`
+> deliberately does **not** apply here. Strip the jargon.
 
-If you have the media, embed it. If you can't produce it, emit a clearly marked
-placeholder so a human captures it before publishing — describe *exactly* what to
-show:
+### Step 6 — Visuals
+
+Every post needs at least one visual — **except a pure fix/roundup digest**,
+where a visual is optional. If you have the media, embed it. If you can't produce
+it, emit a clearly marked placeholder so a human captures it before publishing —
+describe *exactly* what to show:
 
 ```markdown
 > 🎬 **VISUAL PLACEHOLDER — capture before publishing**
@@ -129,45 +201,85 @@ show:
 > Caption: "Filter to 404s and see the matched route inline."
 ```
 
-Prefer a GIF or terminal recording for anything interactive; a screenshot is
-the floor, not the goal.
+Prefer a GIF or terminal recording for anything interactive; a screenshot is the
+floor. A post resting on a placeholder is **ready to hand off for capture**, not
+ready to publish (Step 8).
 
-### Step 7 — Docs links, community hooks, and one CTA
+### Step 7 — Docs links, community credit, and one CTA
 
-- **Docs, never internal issues.** Link the product docs page. **Never** end with
-  "View the details on GitHub" pointing at an internal
-  `enhancements/issues/NNN` work-tracking issue — that's the single most common
-  mistake in past posts. The only GitHub link that belongs is a CLI **compare**
-  link or the resolved **Feature Request** discussion.
-- **Credit the community.** @-mention and thank whoever requested or reported it;
-  link back to the Feature Request discussion this resolves.
-- **One closing CTA.** End with a *single* pointed question that invites a
-  specific reply, and invite a reaction — not a generic "let us know what you
-  think!" Good: "What's the first route you'll add a header rewrite to?"
+**Docs — never invent a URL.** Link only a page you can confirm is published and
+live. If the docs are drafted but not published (e.g. an unmerged docs PR),
+either hold the post until they publish, or emit a placeholder — never guess the
+final URL by analogy:
+
+```markdown
+> 📄 DOCS PLACEHOLDER — confirm the published URL before posting (draft: <PR link>)
+```
+
+**Credit gate.** @-mention **and** link back only when the request/report is in a
+**public** discussion **and** the requester is a community member. For a design
+partner, an NDA user, an internal user, or a private thread: give **generic**
+credit ("thanks to the team who requested this"), no @-mention and no link, or
+flag the person in the Step 8 handoff block for a consent check. The creditable
+discussion can be a feature request, a public design-partner thread, or a bug
+report.
+
+**One CTA.** End with exactly **one** pointed question that invites a *story* or
+an opinion, plus a reaction invite. Anti-patterns:
+
+- No compound "and" questions (that's two questions).
+- No count/metric fishing ("how many orgs are you juggling?").
+- No yes/no questions.
+- Nothing that reads like the banned "let us know what you think!" / "tell us
+  below!"
+
+Good: "What's the first route you'll add a header rewrite to?"
+
+### Step 8 — "Before publishing" handoff block (required)
+
+Every draft ends with a handoff block listing everything a human must clear
+before the post goes live. Include only the rows that apply; omit the block only
+if there is genuinely nothing to confirm (rare). Tell the human to delete this
+block before posting.
+
+```markdown
+> [!WARNING]
+> **⚠️ Before publishing — a human must clear these, then delete this block:**
+> - **Capture visuals:** <what to record/screenshot>
+> - **Confirm docs URLs are live:** <list links; name any that were guessed>
+> - **Verify command syntax:** <blocks/flags to check against --help or docs>
+> - **Confirm unstated claims:** <every [VERIFY] scenario, metric, or limit>
+> - **Consent-check credits:** <named people to confirm are OK to name publicly>
+> - **Excluded on scope:** <out-of-scope items dropped + recommended venue>
+```
 
 ---
 
 ## Self-review checklist
 
-Run this before returning the entry. Every box must be checked.
+Run this before returning the draft. Every rule above is mirrored here — if a
+box can't be checked, fix the draft (a checklist that passes a fabricated URL or
+a compound CTA is worthless).
 
-- [ ] **Title** is benefit-led *and* names the feature (not a bare noun or vague grab-bag); sentence case; `datumctl` lowercase; version paired with headline for CLI releases.
+- [ ] **Title** is benefit-led *and* names the feature (not a bare noun or vague grab-bag); sentence case; `datumctl` lowercase; the claim matches the feature; version paired with headline for CLI releases.
 - [ ] **Lead** is 1–2 sentences in "you can now…" voice — no "excited to announce."
-- [ ] **Jargon glossed** — no CRD / controller / reconcile / webhook / Envoy / BFF or other build-side detail survived.
-- [ ] **Concrete scenario** present — a real "useful when…" the reader recognizes.
-- [ ] **At least one visual** — embedded, or a clearly marked placeholder saying exactly what to capture.
-- [ ] **Docs deep-link(s)** to `datum.net/docs/...` — one per feature.
-- [ ] **No internal issue link** — nothing points at `enhancements/issues/NNN`; only docs, a Feature Request discussion, or a CLI compare link.
-- [ ] **Community credited** where applicable (@-mention + resolved Feature Request link).
-- [ ] **Single closing CTA** — one pointed question, plus a reaction invite.
-- [ ] **CLI releases** carry a `Full changelog:` compare-link footer.
-- [ ] **Scope is clean** — no marketing/company news; not a sub-100-word stub that should be a digest.
+- [ ] **No invented specifics** — every scenario, metric, URL, version, command, and product limit reflects the input or is marked `[VERIFY]` and listed in the handoff block.
+- [ ] **Jargon glossed** — no CRD / controller / reconcile / webhook / pagination / transport / BFF or other build-side term survived; observable effects (smaller/faster) kept but user-framed with the mechanism dropped.
+- [ ] **Concrete scenario is sourced** — the "useful when…" is true of this feature, not borrowed or inferred as fact.
+- [ ] **At least one visual** (or a marked placeholder saying exactly what to capture) — except a pure digest, where it's optional.
+- [ ] **Docs URLs confirmed live** — none invented; pending docs use a DOCS PLACEHOLDER; one 📖 link per major/new feature (Improved/Fixed don't need one).
+- [ ] **No internal issue link** — nothing points at `enhancements/issues/NNN`; PR, compare, and live-docs links are fine.
+- [ ] **Breaking changes** carry a `### Heads-up` group with migration path (+ any deadline); **security fixes** state what/who without exploit detail.
+- [ ] **Credit is safe** — any @-mention is a public community member from a public discussion; design partners/NDA/internal get generic credit or a consent-check in the handoff block.
+- [ ] **Exactly one CTA question** — no compound "and", no count/metric fishing, no yes/no; invites a story; no "let us know!" / "tell us below!"
+- [ ] **CLI releases** carry a `Full changelog:` compare-link footer, and code blocks use verified syntax (or the block is omitted and flagged).
+- [ ] **Scope is clean** — no marketing/company/cosmetic-UI content silently included; anything a stakeholder asked for but that's out of scope is excluded and surfaced in the handoff block.
+- [ ] **Handoff block present** listing every visual, unconfirmed URL, syntax, `[VERIFY]` claim, credit to consent-check, and excluded item.
 
 ---
 
 ## Related
 
 - `gtm-templates` — Keep-a-Changelog *release file* format and other GTM
-  templates. Complementary, not a substitute for this skill.
-- `template.md` — fill-in skeleton for the post.
-- `example.md` — raw notes → finished post, worked end to end.
+  templates; complementary, not a substitute. `template.md` and `example.md`
+  here cover the fill-in skeleton and a full worked run.

--- a/plugins/datum-gtm/skills/changelog-entry/SKILL.md
+++ b/plugins/datum-gtm/skills/changelog-entry/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: changelog-entry
+description: >
+  Write a changelog entry for Datum Cloud's GitHub Discussions Changelog
+  category that meets Datum's content standards. Turns raw engineering notes,
+  PR/issue links, commit messages, or a one-line feature description into a
+  ready-to-post discussion title and markdown body. Use when someone says
+  "write a changelog entry", "announce this in the changelog", or "post this to
+  the changelog discussions" — this is the community-facing changelog POST, not
+  the Keep a Changelog release file (that lives in `gtm-templates`).
+---
+
+# Changelog Entry
+
+Produce a ready-to-post entry for the [Datum Cloud Changelog discussions](https://github.com/orgs/datum-cloud/discussions/categories/changelog):
+a benefit-led **title** plus a markdown **body**. The reader is a Datum *user*
+deciding whether this changes what they can do today — not an engineer reviewing
+the implementation.
+
+**This is a different artifact from `gtm-templates`.** `gtm-templates` covers the
+Keep-a-Changelog *release file* (`### Added / Changed / Fixed` in a repo's
+`CHANGELOG.md`). This skill produces a *community discussion post*: narrative,
+visual, and written for users. Don't paste a Keep-a-Changelog block into a
+discussion — reshape it with this skill.
+
+Model to imitate: **[datumctl v0.16.0 — Bring your own plugin catalog](https://github.com/datum-cloud/datum/discussions/259)**
+(context-then-benefit lead, `###` sections, fenced code, `> [!NOTE]` callouts,
+per-section 📖 docs links, compare-link footer).
+
+Use `template.md` for the fill-in skeleton and `example.md` for a full worked
+run (raw notes → finished post).
+
+---
+
+## Process
+
+### Step 1 — Gather inputs
+
+From the notes/PRs/commits, pull out (and ask the requester only for what's
+genuinely missing):
+
+- **What a user can now do** — the capability, in plain terms.
+- **Who benefits and the concrete "so what"** — a real scenario, e.g. "useful
+  when your upstream routes traffic by hostname — multi-tenant SaaS,
+  virtual-hosted buckets, model gateways that key off the request host."
+- **The docs page** that covers it (a `datum.net/docs/...` deep link).
+- **Community to credit** — anyone who requested or reported this, and the
+  Feature Request / bug discussion it resolves.
+- **Media** — is there a screenshot, GIF, or terminal recording? If not, you'll
+  emit a placeholder (Step 6).
+- **For a CLI release** — the version and the previous version (for the
+  compare-link footer).
+
+### Step 2 — Classify the entry (and gate on scope)
+
+| Type | Signal | Shape |
+|------|--------|-------|
+| **CLI release** | `datumctl vX.Y.Z`, a tag, release notes | Title pairs version + headline feature; body has hero feature + grouped changes + **compare-link footer** |
+| **Feature launch** | one substantial user-facing capability | Benefit title; hero feature section with visual; docs link |
+| **Digest / roundup** | several small changes, none a headline on its own | Benefit title (not a grab-bag); changes grouped under New / Improved / Fixed |
+
+**Scope gate — stop before drafting if:**
+
+- **Not a product change.** Company/marketing news (handbook, website nav,
+  design-system, hiring) does **not** belong in the changelog. Redirect to a
+  blog post (`gtm-templates`) or drop it.
+- **Too thin to stand alone.** A stub under ~100 words of real substance should
+  be **held and merged into the next digest**, not posted by itself. Say so
+  instead of padding it.
+
+### Step 3 — Write the title
+
+Benefit-led **and** feature-named. Sentence case. `datumctl` always lowercase.
+
+| Do | Don't |
+|----|-------|
+| `Access logs: debug routing without leaving the dashboard` | `Access logs` (bare noun) |
+| `datumctl v0.16.0 — Bring your own plugin catalog` | `datumctl v0.16.0` (version only) |
+| `Rewrite the Host header per route` | `AI Edge, Connectors, and Improvements` (vague grab-bag) |
+
+Name the feature, lead with the payoff. Avoid opening every title with
+"Introducing X" — vary it. For a CLI release, pair the version with the headline
+feature using an em-dash (`—`).
+
+### Step 4 — Draft the body (fixed structure)
+
+Follow `template.md`:
+
+1. **Lead paragraph** — what you can now do + why it matters, 1–2 sentences, in
+   "you can now…" voice. No preamble, no "we're excited to announce."
+2. **Hero feature** — the headline change, with the visual (Step 6) and a
+   concrete scenario. Use `###` headings and fenced code for commands/config.
+3. **Remaining changes** — grouped under `### New`, `### Improved`, `### Fixed`
+   (omit any group that's empty). One line each, benefit-first.
+4. **Docs deep-links** — a 📖 link per feature to `datum.net/docs/...`.
+5. **Closing** — community credit + a single pointed question (Step 7).
+6. **Footer (CLI releases)** — `**Full changelog:** [vA...vB](compare-url)`.
+
+Use `> [!NOTE]` / `> [!IMPORTANT]` callouts for upgrade or compatibility notes,
+as in the gold-standard post.
+
+### Step 5 — Voice pass: translate engineer-speak to user outcomes
+
+Rewrite anything that describes *how it was built* into *what the user gets*.
+Cut internal implementation trivia entirely (e.g. "Replaced the Express BFF with
+Hono, 93% smaller" — a user does not care). Gloss or remove Kubernetes jargon:
+
+| Engineer wrote | User reads |
+|----------------|------------|
+| "Added the `AccessLogConfig` CRD, reconciled by the logging-controller" | "Turn on access logs for any proxy" |
+| "reconciliation loop now converges faster" | "changes take effect in seconds" |
+| "logs stream from Envoy via the activity pipeline" | "your live traffic shows up in the dashboard" |
+| "exposed a new field on the spec" | "a new setting lets you…" |
+
+If a term (CRD, controller, reconcile, webhook, informer) survives into the
+draft, it's a bug — replace it with the outcome.
+
+### Step 6 — Visuals (every post needs at least one)
+
+If you have the media, embed it. If you can't produce it, emit a clearly marked
+placeholder so a human captures it before publishing — describe *exactly* what to
+show:
+
+```markdown
+> 🎬 **VISUAL PLACEHOLDER — capture before publishing**
+> Show: filtering the access-log stream by status code, then clicking a 404 to
+>       reveal which host/route matched.
+> Format: GIF (or terminal recording via asciinema/vhs for CLI features).
+> Caption: "Filter to 404s and see the matched route inline."
+```
+
+Prefer a GIF or terminal recording for anything interactive; a screenshot is
+the floor, not the goal.
+
+### Step 7 — Docs links, community hooks, and one CTA
+
+- **Docs, never internal issues.** Link the product docs page. **Never** end with
+  "View the details on GitHub" pointing at an internal
+  `enhancements/issues/NNN` work-tracking issue — that's the single most common
+  mistake in past posts. The only GitHub link that belongs is a CLI **compare**
+  link or the resolved **Feature Request** discussion.
+- **Credit the community.** @-mention and thank whoever requested or reported it;
+  link back to the Feature Request discussion this resolves.
+- **One closing CTA.** End with a *single* pointed question that invites a
+  specific reply, and invite a reaction — not a generic "let us know what you
+  think!" Good: "What's the first route you'll add a header rewrite to?"
+
+---
+
+## Self-review checklist
+
+Run this before returning the entry. Every box must be checked.
+
+- [ ] **Title** is benefit-led *and* names the feature (not a bare noun or vague grab-bag); sentence case; `datumctl` lowercase; version paired with headline for CLI releases.
+- [ ] **Lead** is 1–2 sentences in "you can now…" voice — no "excited to announce."
+- [ ] **Jargon glossed** — no CRD / controller / reconcile / webhook / Envoy / BFF or other build-side detail survived.
+- [ ] **Concrete scenario** present — a real "useful when…" the reader recognizes.
+- [ ] **At least one visual** — embedded, or a clearly marked placeholder saying exactly what to capture.
+- [ ] **Docs deep-link(s)** to `datum.net/docs/...` — one per feature.
+- [ ] **No internal issue link** — nothing points at `enhancements/issues/NNN`; only docs, a Feature Request discussion, or a CLI compare link.
+- [ ] **Community credited** where applicable (@-mention + resolved Feature Request link).
+- [ ] **Single closing CTA** — one pointed question, plus a reaction invite.
+- [ ] **CLI releases** carry a `Full changelog:` compare-link footer.
+- [ ] **Scope is clean** — no marketing/company news; not a sub-100-word stub that should be a digest.
+
+---
+
+## Related
+
+- `gtm-templates` — Keep-a-Changelog *release file* format and other GTM
+  templates. Complementary, not a substitute for this skill.
+- `template.md` — fill-in skeleton for the post.
+- `example.md` — raw notes → finished post, worked end to end.

--- a/plugins/datum-gtm/skills/changelog-entry/SKILL.md
+++ b/plugins/datum-gtm/skills/changelog-entry/SKILL.md
@@ -86,6 +86,12 @@ missing rather than filling it in yourself — see the Ground rule):
 | **Feature launch** | one substantial user-facing capability | Benefit title; hero feature section with visual; docs link |
 | **Digest / roundup** | several small changes, none a headline on its own | Benefit title (not a grab-bag); **no hero** — go straight to grouped changes |
 
+**A digest may carry a breaking change or security fix** — that alone doesn't
+force a hero or a separate post. Render the `### Heads-up` / `### Security` groups
+(Step 4) *above* New/Improved/Fixed, and if a breaking change has a hard
+deadline, make the title signal it (e.g. name the replacement API). A breaking
+change big enough to need its own migration narrative gets its own post instead.
+
 **Scope gate — stop before drafting if:**
 
 - **Not a product change.** Company/marketing news (handbook, website nav,
@@ -123,28 +129,36 @@ feature using an em-dash (`—`).
 Follow `template.md`:
 
 1. **Lead paragraph** — what you can now do + why it matters, 1–2 sentences, in
-   "you can now…" voice. No preamble, no "we're excited to announce."
+   "you can now…" voice. No preamble, no "we're excited to announce." For a
+   digest, the lead spans the batch: "This release speeds up search, localizes
+   log timestamps, and adds CSV export."
 2. **Hero feature** — the headline change, with the visual (Step 6) and its
    concrete scenario. Use `###` headings and fenced code for commands/config.
    *A pure digest has no single hero — omit this and go straight to the groups.*
 3. **Remaining changes** — grouped under `### New`, `### Improved`, `### Fixed`
    (omit empty groups; one benefit-first line each). The hero is **not** repeated
    under `### New`. Don't restate the lead's scenario verbatim in a group.
-4. **Breaking changes / deprecations** — if any, a `### Heads-up` group rendered
-   with `> [!IMPORTANT]`, stating the **migration path** and any **deadline**.
-   Never bury a breaking change inside `### Fixed`.
-5. **Security fixes** — say what was fixed and who should act; do **not** publish
-   exploit detail. Link the advisory and credit the reporter only if the
-   disclosure is already public.
+4. **Breaking changes / deprecations** — if any, a `### Heads-up` group
+   (`> [!IMPORTANT]`) rendered **above** New/Improved/Fixed, stating the
+   **migration path** and any **deadline**. Never bury one inside `### Fixed`.
+5. **Security fixes** — if any, an explicit `### Security` group, also **above**
+   New/Improved/Fixed. Say what was fixed and who should act; do **not** publish
+   exploit detail. Link the advisory — or `[VERIFY: add link once published]` if
+   it isn't live yet — and credit the reporter only if disclosure is public. Say
+   "fix is deployed, no action needed" only if the input supports it; otherwise
+   mark it `[VERIFY]`.
 6. **Docs deep-links** — one 📖 link per **major/new** feature to a live
    `datum.net/docs/...` page (Step 7). `Improved` and `Fixed` lines don't need
    their own docs link.
 7. **Closing** — community credit + a single pointed question (Step 7).
-8. **Footer (CLI releases)** — `**Full changelog:** [vA...vB](compare-url)`.
+8. **Footer (versioned CLI releases only)** — `**Full changelog:** [vA...vB](compare-url)`.
+   An unversioned CLI change inside a digest is just a New/Improved line — no footer.
 
 **Code blocks must use real syntax.** In a CLI post the fenced block is what
 users copy — don't invent flags or argument shapes. Verify against `--help`/docs;
-if the syntax is unknown, ask or omit the block and flag it in Step 8.
+if the syntax is unknown, ask or omit the block and flag it in Step 8. When you
+can't run `--help`/docs in the drafting environment, keep your best draft of the
+block but flag it in the handoff block — that's the expected path, not a blocker.
 
 **Callouts only when earned.** Use `> [!NOTE]` / `> [!IMPORTANT]` for genuine
 upgrade or compatibility notes. If there's no real note, omit the callout — don't
@@ -216,6 +230,10 @@ final URL by analogy:
 > 📄 DOCS PLACEHOLDER — confirm the published URL before posting (draft: <PR link>)
 ```
 
+Any link that will exist but doesn't yet — a security advisory, a launch blog —
+gets the same treatment: mark it `[VERIFY: add link once published]` and add a
+handoff row rather than guessing the URL.
+
 **Credit gate.** @-mention **and** link back only when the request/report is in a
 **public** discussion **and** the requester is a community member. For a design
 partner, an NDA user, an internal user, or a private thread: give **generic**
@@ -267,9 +285,9 @@ a compound CTA is worthless).
 - [ ] **Jargon glossed** — no CRD / controller / reconcile / webhook / pagination / transport / BFF or other build-side term survived; observable effects (smaller/faster) kept but user-framed with the mechanism dropped.
 - [ ] **Concrete scenario is sourced** — the "useful when…" is true of this feature, not borrowed or inferred as fact.
 - [ ] **At least one visual** (or a marked placeholder saying exactly what to capture) — except a pure digest, where it's optional.
-- [ ] **Docs URLs confirmed live** — none invented; pending docs use a DOCS PLACEHOLDER; one 📖 link per major/new feature (Improved/Fixed don't need one).
+- [ ] **Docs URLs confirmed live** — none invented; pending docs (or any not-yet-published link like an advisory/blog) use a placeholder or `[VERIFY]`; one 📖 link per major/new feature (Improved/Fixed don't need one).
 - [ ] **No internal issue link** — nothing points at `enhancements/issues/NNN`; PR, compare, and live-docs links are fine.
-- [ ] **Breaking changes** carry a `### Heads-up` group with migration path (+ any deadline); **security fixes** state what/who without exploit detail.
+- [ ] **Breaking changes** get a `### Heads-up` group (migration path + any deadline) and **security fixes** an explicit `### Security` group — both rendered above New/Improved/Fixed, without exploit detail; a hard-deadline breaking change is signaled in the title.
 - [ ] **Credit is safe** — any @-mention is a public community member from a public discussion; design partners/NDA/internal get generic credit or a consent-check in the handoff block.
 - [ ] **Exactly one CTA question** — no compound "and", no count/metric fishing, no yes/no; invites a story; no "let us know!" / "tell us below!"
 - [ ] **CLI releases** carry a `Full changelog:` compare-link footer, and code blocks use verified syntax (or the block is omitted and flagged).

--- a/plugins/datum-gtm/skills/changelog-entry/example.md
+++ b/plugins/datum-gtm/skills/changelog-entry/example.md
@@ -1,0 +1,107 @@
+# Worked Example
+
+One end-to-end run: the messy input an engineer hands over, and the finished
+changelog post produced from it. Read this alongside `SKILL.md` to see each
+standard applied.
+
+---
+
+## Input (raw engineering notes)
+
+> - shipped access logs UI for HTTPProxy. logs stream from Envoy via the
+>   activity pipeline into the dashboard. can filter by status code, host, path.
+> - added: export the current view to CSV.
+> - improved: search now hits the new index, ~5x faster on big projects.
+> - fixed: timestamps showed UTC instead of the viewer's tz. now localized.
+> - this was our #1 feature request — discussion #180 from @maria-dev, runs a
+>   multi-tenant SaaS, needed to debug 404s by hostname.
+> - docs: datum.net/docs/observability/access-logs
+> - impl: added AccessLogConfig CRD, reconciled by logging-controller. new
+>   read path goes through the activity read model. (internal, don't publish)
+
+## How it gets classified
+
+- **Entry type:** Feature launch with a few secondary changes → hero feature +
+  `New` / `Improved` / `Fixed` groups.
+- **Scope gate:** user-facing product change, well over 100 words of substance —
+  post it on its own. ✅
+- **Credit:** @maria-dev requested it in #180 → thank + link.
+- **Jargon to kill:** `HTTPProxy`, `Envoy`, `activity pipeline`,
+  `AccessLogConfig CRD`, `logging-controller`, `activity read model` — none of
+  these reach the reader.
+- **Visual:** no media provided → emit a placeholder describing the filter-to-404
+  flow (the concrete scenario from @maria-dev).
+
+## Output (finished post)
+
+### Title
+
+```
+Access logs: debug routing without leaving the dashboard
+```
+
+### Body
+
+```markdown
+You can now see every request hitting your proxies in the dashboard, and filter
+to exactly the ones you care about — no log shipping or third-party tooling to
+set up.
+
+### Live access logs, filtered your way
+
+Open **Observability → Access logs** and your traffic streams in as it happens.
+Filter by status code, host, or path to zero in on a problem. Useful when your
+upstream routes by hostname — multi-tenant SaaS, virtual-hosted buckets, model
+gateways that key off the request host — and you need to know *which* host a
+request actually matched.
+
+> 🎬 **VISUAL PLACEHOLDER — capture before publishing**
+> Show: filtering the live log stream down to status `404`, then clicking a row
+>       to reveal the host and route that matched the request.
+> Format: GIF.
+> Caption: "Filter to 404s and see the matched host and route inline."
+
+📖 [Access logs](https://datum.net/docs/observability/access-logs)
+
+### New
+
+- **Export to CSV** — download the current filtered view for a spreadsheet,
+  a ticket, or an auditor. 📖 [Exporting logs](https://datum.net/docs/observability/access-logs#export)
+
+### Improved
+
+- **Search is ~5x faster** — filtering large projects that used to lag now
+  returns near-instantly.
+
+### Fixed
+
+- **Timestamps now match your timezone** — log times display in your local
+  timezone instead of UTC, so what you see lines up with when it happened.
+
+Thanks to @maria-dev for raising this in [#180](https://github.com/datum-cloud/datum/discussions/180) —
+it was our most-requested feature.
+
+What's the first thing you'll go looking for in your access logs? Tell us below,
+and react with 👍 if faster incident debugging is on your list.
+```
+
+---
+
+## Why this passes the checklist
+
+- **Title** names the feature (*access logs*) and leads with the payoff (*debug
+  routing without leaving the dashboard*) — not the bare noun "Access logs."
+- **Lead** is one sentence in "you can now…" voice and answers *why it matters*
+  (no setup).
+- **Jargon glossed** — "Envoy via the activity pipeline" became "your traffic
+  streams in"; the CRD and controller are gone entirely.
+- **Concrete scenario** — the multi-tenant / virtual-hosted / model-gateway
+  "useful when…" the reader recognizes.
+- **Visual placeholder** describes the exact flow to capture and the format.
+- **Docs links** point at `datum.net/docs/...`; the internal `AccessLogConfig` /
+  controller note never appears, and there's **no** "view details on GitHub"
+  issue link.
+- **Community credited** — @maria-dev thanked, discussion #180 linked as the
+  resolved request.
+- **Single closing question** invites a specific reply and a reaction, rather
+  than a generic "let us know!"

--- a/plugins/datum-gtm/skills/changelog-entry/example.md
+++ b/plugins/datum-gtm/skills/changelog-entry/example.md
@@ -1,38 +1,45 @@
 # Worked Example
 
-One end-to-end run: the messy input an engineer hands over, and the finished
-changelog post produced from it. Read this alongside `SKILL.md` to see each
-standard applied.
+One end-to-end run: the messy input an engineer hands over, and the complete
+draft produced from it — including the handoff block a human clears before
+publishing. Read this alongside `SKILL.md` to see each rule applied. Note where
+the input is *incomplete*: the draft marks those spots rather than inventing.
 
 ---
 
 ## Input (raw engineering notes)
 
-> - shipped access logs UI for HTTPProxy. logs stream from Envoy via the
->   activity pipeline into the dashboard. can filter by status code, host, path.
-> - added: export the current view to CSV.
-> - improved: search now hits the new index, ~5x faster on big projects.
-> - fixed: timestamps showed UTC instead of the viewer's tz. now localized.
-> - this was our #1 feature request — discussion #180 from @maria-dev, runs a
->   multi-tenant SaaS, needed to debug 404s by hostname.
-> - docs: datum.net/docs/observability/access-logs
-> - impl: added AccessLogConfig CRD, reconciled by logging-controller. new
->   read path goes through the activity read model. (internal, don't publish)
+> - shipped access logs UI. users watch live requests to their proxies in the
+>   dashboard and filter by status code, host, path. docs are LIVE at
+>   datum.net/docs/observability/access-logs
+> - new: export the current filtered view to CSV. (docs for the export bit
+>   aren't written yet — docs team has a draft in PR datum-cloud/docs#521)
+> - improved: search is way faster on big projects now — maybe ~5x, rough number
+> - fixed: timestamps showed UTC, now localized to the viewer's timezone
+> - #1 feature request: discussion #180 from @maria-dev, a community user running
+>   a multi-tenant SaaS who needed to debug 404s by hostname
+> - marketing also asked us to plug the new pricing page in this post
+> - no screenshots captured yet
+> - impl (don't publish): AccessLogConfig CRD reconciled by logging-controller;
+>   read path via the activity read model
 
 ## How it gets classified
 
-- **Entry type:** Feature launch with a few secondary changes → hero feature +
+- **Entry type:** Feature launch with secondary changes → hero feature +
   `New` / `Improved` / `Fixed` groups.
-- **Scope gate:** user-facing product change, well over 100 words of substance —
-  post it on its own. ✅
-- **Credit:** @maria-dev requested it in #180 → thank + link.
-- **Jargon to kill:** `HTTPProxy`, `Envoy`, `activity pipeline`,
-  `AccessLogConfig CRD`, `logging-controller`, `activity read model` — none of
-  these reach the reader.
-- **Visual:** no media provided → emit a placeholder describing the filter-to-404
-  flow (the concrete scenario from @maria-dev).
+- **Scope gate:** the access-logs feature is a real user-facing change, well over
+  100 words → post it. The **pricing-page plug marketing asked for is out of
+  scope** (marketing news) → excluded from the post, surfaced in the handoff
+  block, not silently dropped.
+- **Credit:** @maria-dev is a community user in a public discussion (#180) →
+  safe to @-mention and link directly.
+- **Jargon to kill:** `AccessLogConfig CRD`, `logging-controller`, `reconciled`,
+  `activity read model` — none reach the reader.
+- **Incomplete inputs, handled not invented:** export docs aren't published
+  (→ DOCS PLACEHOLDER); the "~5x" figure is rough (→ `[VERIFY]`); no media
+  (→ visual placeholder).
 
-## Output (finished post)
+## Output (complete draft)
 
 ### Title
 
@@ -51,9 +58,8 @@ set up.
 
 Open **Observability → Access logs** and your traffic streams in as it happens.
 Filter by status code, host, or path to zero in on a problem. Useful when your
-upstream routes by hostname — multi-tenant SaaS, virtual-hosted buckets, model
-gateways that key off the request host — and you need to know *which* host a
-request actually matched.
+upstream routes by hostname — a multi-tenant SaaS where a single 404 could be any
+of your tenants — and you need to know *which* host a request actually matched.
 
 > 🎬 **VISUAL PLACEHOLDER — capture before publishing**
 > Show: filtering the live log stream down to status `404`, then clicking a row
@@ -65,13 +71,14 @@ request actually matched.
 
 ### New
 
-- **Export to CSV** — download the current filtered view for a spreadsheet,
-  a ticket, or an auditor. 📖 [Exporting logs](https://datum.net/docs/observability/access-logs#export)
+- **Export to CSV** — download the current filtered view for a spreadsheet, a
+  ticket, or an auditor.
+  > 📄 DOCS PLACEHOLDER — confirm the published URL before posting (draft: datum-cloud/docs#521)
 
 ### Improved
 
-- **Search is ~5x faster** — filtering large projects that used to lag now
-  returns near-instantly.
+- **Search is much faster on large projects** — filtering long histories that
+  used to lag now returns quickly (around 5×). `[VERIFY: confirm the ~5× figure]`
 
 ### Fixed
 
@@ -81,27 +88,39 @@ request actually matched.
 Thanks to @maria-dev for raising this in [#180](https://github.com/datum-cloud/datum/discussions/180) —
 it was our most-requested feature.
 
-What's the first thing you'll go looking for in your access logs? Tell us below,
-and react with 👍 if faster incident debugging is on your list.
+What's the routing mystery you'll finally get to the bottom of with access logs?
+React with 👍 if faster incident debugging has been on your list.
+
+> [!WARNING]
+> **⚠️ Before publishing — a human must clear these, then delete this block:**
+> - **Capture visuals:** the 404-filter GIF described in the hero placeholder.
+> - **Confirm docs URLs are live:** the export CSV page (draft in docs#521) is
+>   not published — replace the placeholder with the live URL or hold that line.
+>   The Access logs page is stated live; sanity-check it resolves.
+> - **Confirm unstated claims:** the "~5×" search figure is a rough dev number —
+>   confirm or soften before publishing.
+> - **Excluded on scope:** marketing asked to plug the new pricing page — left
+>   out as marketing news; suggest a blog post or the pricing page's own channel.
 ```
 
 ---
 
 ## Why this passes the checklist
 
-- **Title** names the feature (*access logs*) and leads with the payoff (*debug
-  routing without leaving the dashboard*) — not the bare noun "Access logs."
-- **Lead** is one sentence in "you can now…" voice and answers *why it matters*
-  (no setup).
-- **Jargon glossed** — "Envoy via the activity pipeline" became "your traffic
-  streams in"; the CRD and controller are gone entirely.
-- **Concrete scenario** — the multi-tenant / virtual-hosted / model-gateway
-  "useful when…" the reader recognizes.
-- **Visual placeholder** describes the exact flow to capture and the format.
-- **Docs links** point at `datum.net/docs/...`; the internal `AccessLogConfig` /
-  controller note never appears, and there's **no** "view details on GitHub"
-  issue link.
-- **Community credited** — @maria-dev thanked, discussion #180 linked as the
-  resolved request.
-- **Single closing question** invites a specific reply and a reaction, rather
-  than a generic "let us know!"
+- **Title** names the feature and leads with the payoff — not the bare noun.
+- **Lead** is one sentence in "you can now…" voice, answering *why it matters*.
+- **No invented specifics** — the scenario comes straight from @maria-dev's
+  request; the rough metric is flagged `[VERIFY]`, not stated as fact; the
+  unpublished export docs use a DOCS PLACEHOLDER instead of a guessed URL.
+- **Jargon glossed** — the CRD, controller, and read-model are gone.
+- **Docs** point at a confirmed-live page (hero) and a placeholder (export); no
+  internal `enhancements/issues` link appears.
+- **Credit is safe** — @maria-dev is a public community member from a public
+  discussion, so the direct @-mention and link are fine.
+- **One CTA** invites a *story* ("the routing mystery you'll finally get to the
+  bottom of"), not a number or a yes/no, and isn't "let us know!"
+- **Scope is clean** — the pricing-page plug is excluded and surfaced in the
+  handoff block, not silently dropped.
+- **Handoff block** lists every visual, unconfirmed URL, `[VERIFY]` claim, and
+  excluded item — so the reviewer knows exactly what stands between this draft
+  and publish.

--- a/plugins/datum-gtm/skills/changelog-entry/template.md
+++ b/plugins/datum-gtm/skills/changelog-entry/template.md
@@ -1,8 +1,10 @@
 # Changelog Post Template
 
 Fill in the placeholders. Delete any section that doesn't apply (e.g. omit an
-empty `### Improved` group, or the compare-link footer for a non-CLI post).
-Notes in `<!-- ... -->` are guidance — remove them from the final post.
+empty `### Improved` group, the hero for a pure digest, or the compare-link
+footer for a non-CLI post). Notes in `<!-- ... -->` are guidance — remove them
+from the final post. Never invent a value to fill a slot: if the input doesn't
+give it, ask or mark it `[VERIFY: ...]` and list it in the handoff block.
 
 ---
 
@@ -25,47 +27,74 @@ Notes in `<!-- ... -->` are guidance — remove them from the final post.
 <!-- LEAD: 1–2 sentences, "you can now…" voice. What you can do + why it matters. -->
 You can now <capability> — <why it matters to the reader>.
 
-<!-- HERO FEATURE: the headline change. -->
+<!-- HERO FEATURE: the headline change. OMIT for a pure digest (no single hero). -->
 ### <Headline feature, benefit-first>
 
 <One or two sentences on what it does.> Useful when <concrete "so what"
-scenario the reader will recognize — a real workflow, not a category>.
+scenario FROM THE INPUT — mark [VERIFY] if the input didn't give one>.
 
 > 🎬 **VISUAL PLACEHOLDER — capture before publishing**
 > Show: <exactly what to demonstrate>.
 > Format: <GIF | terminal recording | screenshot>.
 > Caption: <one-line caption>.
 
-<!-- Optional fenced example: a command or config the reader would actually run. -->
+<!-- Optional fenced example: a command or config the reader would actually run.
+     CLI syntax must be REAL — verify against --help/docs, don't invent flags. -->
 ```bash
-datumctl <example command>
+datumctl <verified example command>
 ```
 
 > [!NOTE]
-> <Upgrade, compatibility, or "no action needed" note, if any.>
+> <A genuine upgrade/compatibility note, if any. Omit the callout if there isn't one.>
 
+<!-- DOCS: link only if the page is published and live. If not, use the placeholder. -->
 📖 [<Docs link text>](https://datum.net/docs/<path>)
+> 📄 DOCS PLACEHOLDER — confirm the published URL before posting (draft: <PR link>)
 
-<!-- REMAINING CHANGES: keep only the groups that have items. One line each, benefit-first. -->
+<!-- REMAINING CHANGES: keep only the groups that have items. One line each,
+     benefit-first. Do NOT repeat the hero here. -->
 ### New
 
 - **<Change>** — <what the user gets>. 📖 [<docs>](https://datum.net/docs/<path>)
 
 ### Improved
 
-- **<Change>** — <what's better now, in user terms>.
+- **<Change>** — <what's better now, in user terms>. <!-- no docs link needed -->
 
 ### Fixed
 
 - **<Change>** — <the symptom the user no longer hits>.
 
-<!-- CLOSING: community credit + ONE pointed question + reaction invite. -->
-Thanks to @<username> for <requesting/reporting> this in <#discussion-link>.
+<!-- HEADS-UP: only if there's a breaking change / deprecation / removal. -->
+### Heads-up
 
-<A single pointed question that invites a specific reply.> React with 👍 if <…>.
+> [!IMPORTANT]
+> **<What's changing and by when.>** <Migration path: what the reader must do,
+> and the deadline if there is one.>
+
+<!-- SECURITY: say what was fixed and who should act; NO exploit detail.
+     Link the advisory / credit the reporter only if disclosure is public. -->
+
+<!-- CLOSING: community credit + ONE pointed question + reaction invite. -->
+Thanks to @<username> for <requesting/reporting> this in <#public-discussion-link>.
+<!-- @-mention + link only a PUBLIC community member from a PUBLIC discussion.
+     Design partner / NDA / internal → generic credit, no @-mention, no link. -->
+
+<A single story-inviting question — no compound "and", no count/metric, no yes/no.>
+React with 👍 if <…>.
 
 <!-- FOOTER: CLI releases only. -->
 **Full changelog:** [v<A>...v<B>](https://github.com/datum-cloud/<repo>/compare/v<A>...v<B>)
+
+<!-- HANDOFF: required. List everything a human must clear, then they delete this block. -->
+> [!WARNING]
+> **⚠️ Before publishing — a human must clear these, then delete this block:**
+> - **Capture visuals:** <what to record/screenshot>
+> - **Confirm docs URLs are live:** <list links; name any that were guessed>
+> - **Verify command syntax:** <blocks/flags to check against --help or docs>
+> - **Confirm unstated claims:** <every [VERIFY] scenario, metric, or limit>
+> - **Consent-check credits:** <named people to confirm are OK to name publicly>
+> - **Excluded on scope:** <out-of-scope items dropped + recommended venue>
 ```
 
 ---
@@ -75,10 +104,13 @@ Thanks to @<username> for <requesting/reporting> this in <#discussion-link>.
 | Section | Required? | Notes |
 |---------|-----------|-------|
 | Lead paragraph | Always | 1–2 sentences, "you can now…", no "excited to announce" |
-| Hero feature (`###`) | Always | The headline change + the visual + a concrete scenario |
-| Visual placeholder | Always (unless media embedded) | Say exactly what to capture and in what format |
-| `### New / Improved / Fixed` | If there are secondary changes | Omit empty groups; one benefit-first line each |
-| 📖 docs link | One per feature | `datum.net/docs/...` — never an internal issue link |
-| Community credit | When someone requested/reported it | @-mention + link the Feature Request discussion |
-| Closing question | Always | One pointed question + reaction invite |
+| Hero feature (`###`) | Always, except a pure digest | The headline change + the visual + a sourced scenario |
+| Visual placeholder | Always, except a pure digest | Say exactly what to capture and in what format |
+| `### New / Improved / Fixed` | If there are secondary changes | Omit empty groups; one benefit-first line each; don't repeat the hero |
+| `### Heads-up` (`> [!IMPORTANT]`) | If there's a breaking change/deprecation | Migration path + deadline |
+| Security wording | If there's a security fix | What/who, no exploit detail; credit only if disclosure is public |
+| 📖 docs link | One per major/new feature | Confirmed-live `datum.net/docs/...`, or a DOCS PLACEHOLDER — never invented |
+| Community credit | When someone requested/reported it | @-mention + link only a public community member from a public discussion |
+| Closing question | Always | One story-inviting question + reaction invite |
 | Compare-link footer | CLI releases only | `compare/vA...vB` |
+| Handoff block (`> [!WARNING]`) | Always (unless nothing to confirm) | Everything a human must clear before publish |

--- a/plugins/datum-gtm/skills/changelog-entry/template.md
+++ b/plugins/datum-gtm/skills/changelog-entry/template.md
@@ -1,0 +1,84 @@
+# Changelog Post Template
+
+Fill in the placeholders. Delete any section that doesn't apply (e.g. omit an
+empty `### Improved` group, or the compare-link footer for a non-CLI post).
+Notes in `<!-- ... -->` are guidance — remove them from the final post.
+
+---
+
+## Title
+
+```
+<Benefit-led, feature-named title in sentence case>
+```
+
+<!--
+  Feature launch: "Access logs: debug routing without leaving the dashboard"
+  CLI release:    "datumctl v0.16.0 — Bring your own plugin catalog"
+  Digest:         "Faster search, localized timestamps, and CSV export"
+  NOT: a bare noun ("Access logs") or a vague grab-bag ("AI, Connectors, and Improvements").
+-->
+
+## Body
+
+```markdown
+<!-- LEAD: 1–2 sentences, "you can now…" voice. What you can do + why it matters. -->
+You can now <capability> — <why it matters to the reader>.
+
+<!-- HERO FEATURE: the headline change. -->
+### <Headline feature, benefit-first>
+
+<One or two sentences on what it does.> Useful when <concrete "so what"
+scenario the reader will recognize — a real workflow, not a category>.
+
+> 🎬 **VISUAL PLACEHOLDER — capture before publishing**
+> Show: <exactly what to demonstrate>.
+> Format: <GIF | terminal recording | screenshot>.
+> Caption: <one-line caption>.
+
+<!-- Optional fenced example: a command or config the reader would actually run. -->
+```bash
+datumctl <example command>
+```
+
+> [!NOTE]
+> <Upgrade, compatibility, or "no action needed" note, if any.>
+
+📖 [<Docs link text>](https://datum.net/docs/<path>)
+
+<!-- REMAINING CHANGES: keep only the groups that have items. One line each, benefit-first. -->
+### New
+
+- **<Change>** — <what the user gets>. 📖 [<docs>](https://datum.net/docs/<path>)
+
+### Improved
+
+- **<Change>** — <what's better now, in user terms>.
+
+### Fixed
+
+- **<Change>** — <the symptom the user no longer hits>.
+
+<!-- CLOSING: community credit + ONE pointed question + reaction invite. -->
+Thanks to @<username> for <requesting/reporting> this in <#discussion-link>.
+
+<A single pointed question that invites a specific reply.> React with 👍 if <…>.
+
+<!-- FOOTER: CLI releases only. -->
+**Full changelog:** [v<A>...v<B>](https://github.com/datum-cloud/<repo>/compare/v<A>...v<B>)
+```
+
+---
+
+## Section reference
+
+| Section | Required? | Notes |
+|---------|-----------|-------|
+| Lead paragraph | Always | 1–2 sentences, "you can now…", no "excited to announce" |
+| Hero feature (`###`) | Always | The headline change + the visual + a concrete scenario |
+| Visual placeholder | Always (unless media embedded) | Say exactly what to capture and in what format |
+| `### New / Improved / Fixed` | If there are secondary changes | Omit empty groups; one benefit-first line each |
+| 📖 docs link | One per feature | `datum.net/docs/...` — never an internal issue link |
+| Community credit | When someone requested/reported it | @-mention + link the Feature Request discussion |
+| Closing question | Always | One pointed question + reaction invite |
+| Compare-link footer | CLI releases only | `compare/vA...vB` |

--- a/plugins/datum-gtm/skills/changelog-entry/template.md
+++ b/plugins/datum-gtm/skills/changelog-entry/template.md
@@ -51,6 +51,20 @@ datumctl <verified example command>
 📖 [<Docs link text>](https://datum.net/docs/<path>)
 > 📄 DOCS PLACEHOLDER — confirm the published URL before posting (draft: <PR link>)
 
+<!-- BREAKING / SECURITY: if they apply, render BOTH groups ABOVE New/Improved/Fixed. -->
+<!-- HEADS-UP: only if there's a breaking change / deprecation / removal. -->
+### Heads-up
+
+> [!IMPORTANT]
+> **<What's changing and by when.>** <Migration path: what the reader must do,
+> and the deadline if there is one.>
+
+<!-- SECURITY: only if there's a security fix. What was fixed + who should act; NO exploit detail. -->
+### Security
+
+- **<What was fixed and who should act>** — <link the advisory, or
+  [VERIFY: add link once published] if it isn't live yet>. <!-- credit the reporter only if disclosure is public -->
+
 <!-- REMAINING CHANGES: keep only the groups that have items. One line each,
      benefit-first. Do NOT repeat the hero here. -->
 ### New
@@ -65,20 +79,11 @@ datumctl <verified example command>
 
 - **<Change>** — <the symptom the user no longer hits>.
 
-<!-- HEADS-UP: only if there's a breaking change / deprecation / removal. -->
-### Heads-up
-
-> [!IMPORTANT]
-> **<What's changing and by when.>** <Migration path: what the reader must do,
-> and the deadline if there is one.>
-
-<!-- SECURITY: say what was fixed and who should act; NO exploit detail.
-     Link the advisory / credit the reporter only if disclosure is public. -->
-
-<!-- CLOSING: community credit + ONE pointed question + reaction invite. -->
+<!-- CLOSING: community credit (if any) + ONE pointed question + reaction invite. -->
 Thanks to @<username> for <requesting/reporting> this in <#public-discussion-link>.
 <!-- @-mention + link only a PUBLIC community member from a PUBLIC discussion.
-     Design partner / NDA / internal → generic credit, no @-mention, no link. -->
+     Design partner / NDA / internal → generic credit, no @-mention, no link.
+     No public requester? Omit this line entirely — the closing is just the CTA. -->
 
 <A single story-inviting question — no compound "and", no count/metric, no yes/no.>
 React with 👍 if <…>.
@@ -107,10 +112,10 @@ React with 👍 if <…>.
 | Hero feature (`###`) | Always, except a pure digest | The headline change + the visual + a sourced scenario |
 | Visual placeholder | Always, except a pure digest | Say exactly what to capture and in what format |
 | `### New / Improved / Fixed` | If there are secondary changes | Omit empty groups; one benefit-first line each; don't repeat the hero |
-| `### Heads-up` (`> [!IMPORTANT]`) | If there's a breaking change/deprecation | Migration path + deadline |
-| Security wording | If there's a security fix | What/who, no exploit detail; credit only if disclosure is public |
+| `### Heads-up` (`> [!IMPORTANT]`) | If there's a breaking change/deprecation | Migration path + deadline; rendered above New/Improved/Fixed |
+| `### Security` | If there's a security fix | What/who, no exploit detail; above New/Improved/Fixed; advisory link or `[VERIFY]`; credit only if disclosure is public |
 | 📖 docs link | One per major/new feature | Confirmed-live `datum.net/docs/...`, or a DOCS PLACEHOLDER — never invented |
-| Community credit | When someone requested/reported it | @-mention + link only a public community member from a public discussion |
+| Community credit | When a public requester exists | @-mention + link only a public community member from a public discussion; omit if none |
 | Closing question | Always | One story-inviting question + reaction invite |
-| Compare-link footer | CLI releases only | `compare/vA...vB` |
+| Compare-link footer | Versioned CLI releases only | `compare/vA...vB` |
 | Handoff block (`> [!WARNING]`) | Always (unless nothing to confirm) | Everything a human must clear before publish |

--- a/plugins/datum-gtm/skills/gtm-templates/SKILL.md
+++ b/plugins/datum-gtm/skills/gtm-templates/SKILL.md
@@ -12,8 +12,12 @@ This skill provides templates for go-to-market communications.
 | Template | Purpose |
 |----------|---------|
 | `templates/blog-post.md` | Launch blog post |
-| `templates/changelog.md` | Changelog entry |
-| `templates/enablement.md` | Internal enablement |
+
+The changelog and enablement formats are documented inline in this file (see
+**Changelog Format** and **Enablement Brief** below); they don't have separate
+template files. For a community-facing changelog *post* to the GitHub Discussions
+Changelog category, use the `changelog-entry` skill instead of the release-file
+format here.
 
 ## Blog Post Structure
 


### PR DESCRIPTION
## Why

The [Changelog category](https://github.com/orgs/datum-cloud/discussions/categories/changelog) isn't reaching the community: 32 posts over 9 months drew **3 comments, all from Datum staff**. The posts read like release plumbing — internal `enhancements/issues/NNN` links instead of docs, unglossed platform jargon, no consistent format. Troubleshooting and Feature Requests show the community engages when a post gives them a reason to.

## What this adds

A `changelog-entry` skill in the datum-gtm plugin that turns raw engineering notes into a community-ready changelog post. Every post gets:

- A **benefit-led title** and "you can now…" voice — implementation jargon translated into user outcomes
- **Live docs links**; internal issue links banned
- A **visual** (or precise capture instructions), a consent-gated community credit, and **one conversation-starting question**
- Proper handling of **breaking changes** (migration path + deadline, never buried in "Fixed") and **security fixes** (who should act, no exploit detail)
- **No invented facts** — unverified URLs, metrics, and claims are marked `[VERIFY]` and collected into a before-publishing checklist for a human

<details>
<summary>Sample output — digest with a breaking change + security fix</summary>

**Title:** Live quota bars, faster activity search, and the v1beta2 activity API

> ### Heads-up
>
> > [!IMPORTANT]
> > **The v1alpha activity API is being removed on September 1, 2026.** Move to the v1beta2 activity API (available now): switch your base path to `/v1beta2` and rename the `filter` query parameter to `q`. See the migration guide for the details.
>
> 📖 [Migrate to the v1beta2 activity API](https://datum.net/docs/api/activity/migrate-v1beta2)
>
> ### Security
>
> - **Fixed an exposure in project-scoped API tokens** — a project-scoped token could read org-level quota settings it shouldn't have. The exposure was read-only (these tokens could not change any setting), and we've found no evidence it was used. The fix is deployed; no action is needed on your part. A GitHub security advisory with full details is going out this week. `[VERIFY: advisory link not live yet — add once published]`

The internal tracker link was deliberately dropped, the private security reporter got generic credit, and every unverified claim is flagged for a human in the post's handoff block.

</details>

## Changes

- **The skill** — `plugins/datum-gtm/skills/changelog-entry/`: `SKILL.md` (process + self-review checklist), `template.md`, `example.md` (worked run)
- **Routing** — `agents/gtm-comms.md` sends community changelog posts here; Keep-a-Changelog release files stay with `gtm-templates`
- **Cleanup** — fixed broken template references in `gtm-templates/SKILL.md`
- **Bookkeeping** — datum-gtm 1.1.0, `CHANGELOG.md` and `README.md` updated

Validated by having independent agents draft posts from raw notes in three scenarios (CLI release, portal feature, mixed digest with breaking change + security fix), with two critic review passes and a re-test after revision.

## Review notes

- `claude plugin validate .` passes; the 2 warnings are pre-existing stale `marketplace.json` entry versions, left for a separate sync
- `docs/skills-and-runbooks.md` tables are stale repo-wide (predates this PR)
- Shared `CHANGELOG.md` numbering: the datum-gtm `1.1.0` entry sits above datum-platform's `1.8.0` history; ordering is chronological

🤖 Generated with [Claude Code](https://claude.com/claude-code)
