### PR TITLE
docs: forbid hard-wrapping in GitHub conventions skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes to the Datum Cloud Claude Code plugins.
 
+## [1.8.1] - 2026-07-09
+
+### Changed
+
+- **GitHub conventions skill** (`pr-conventions`, datum-platform) — Added a rule forbidding hard-wrapped prose in PR descriptions, issues, and comments. GitHub reflows Markdown, so manual fixed-column wrapping (e.g. 80 characters) produces ragged, hard-to-edit text; hard-wrapping belongs only in commit messages. Added as a Core Principle and a row in the PR "What to Avoid" table.
+
 ## [1.1.0] - 2026-07-08
 
 ### Added

--- a/plugins/datum-platform/.claude-plugin/plugin.json
+++ b/plugins/datum-platform/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "datum-platform",
   "description": "Kubernetes platform engineering automation with aggregated API servers, controller patterns, GitOps deployment, and platform capabilities",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": {
     "name": "Datum Cloud",
     "url": "https://github.com/datum-cloud"

--- a/plugins/datum-platform/skills/pr-conventions/SKILL.md
+++ b/plugins/datum-platform/skills/pr-conventions/SKILL.md
@@ -14,6 +14,7 @@ This skill covers how to work with GitHub effectively — writing pull requests,
 - Focus on goals and outcomes, not implementation details.
 - Use comments to add depth — keep the primary description focused.
 - Close issues deliberately. Linking is not closing.
+- Don't hard-wrap prose. GitHub renders Markdown and reflows paragraphs on its own, so insert line breaks only where the syntax needs them (lists, tables, code fences, callouts). Manually wrapping text at a fixed column (e.g. 80 characters) produces ragged lines that reflow badly and are awkward to edit. Hard-wrapping belongs in commit messages, not in PR descriptions, issues, or comments.
 
 ---
 
@@ -111,6 +112,7 @@ Write like you're explaining the change to a teammate. Non-technical stakeholder
 | PRs without an issue link | Every change should trace to intent |
 | Technical jargon in summaries | Not all readers have the same context |
 | Bullet-point-only summaries | Lead with prose for orientation |
+| Hard-wrapping prose at a fixed column | GitHub reflows Markdown — wrap only where syntax requires |
 | Tool attribution / watermarks | Clutters the PR |
 | Empty sections | Omit optional sections rather than leaving them blank |
 


### PR DESCRIPTION
## Summary

The `github-conventions` skill (invoked as `pr-conventions`) covers PR, issue, and comment formatting but says nothing about line wrapping. As a result, agents and contributors following it still hand-wrap PR and issue bodies at ~80 columns, which GitHub then renders as ragged, hard-to-edit prose (example: datum-cloud/infra#3188).

This adds an explicit rule: don't hard-wrap prose in PR descriptions, issues, or comments — GitHub reflows Markdown on its own, so line breaks belong only where the syntax needs them. Hard-wrapping stays confined to commit messages.

## Changes

- Add a Core Principle stating prose must not be hard-wrapped.
- Add a row to the PR "What to Avoid" table.

Docs-only; no behavior change to any tooling.
